### PR TITLE
RWR-154 Fix layout when there are multiple sources in river footer

### DIFF
--- a/html/themes/custom/common_design_subtheme/templates/river-row.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/river-row.html.twig
@@ -42,36 +42,28 @@
 
   <footer>
     <dl class="meta core">
-      <div>
-        <dt class="format {{ row.format|clean_class }} visually-hidden">{{ 'Format'|t }}:</dt>
-        <dd class="format {{ row.format|clean_class }}">{{ row.format|t }}</dd>
-      </div>
+      <dt class="format {{ row.format|clean_class }} visually-hidden">{{ 'Format'|t }}:</dt>
+      <dd class="format {{ row.format|clean_class }}">{{ row.format|t }}</dd>
 
-      <div>
-        <dt class="source">{{ 'Source'|t }}:</dt>
-        <dd class="source">{{ row.sources }}</dd>
-      </div>
+      <dt class="source">{{ 'Source'|t }}:</dt>
+      <dd class="source">{{ row.sources }}</dd>
 
-      <div>
-        <dt class="date posted">{{ 'Posted'|t }}:</dt>
-        <dd class="date posted">{{ row.date_changed|date("d M Y") }}</dd>
-      </div>
+      <dt class="date posted">{{ 'Posted'|t }}:</dt>
+      <dd class="date posted">{{ row.date_changed|date("d M Y") }}</dd>
 
       {% if row.files|length > 0 %}
-      <div>
-        <dt class="files">{{ 'Files'|t }}:</dt>
-        <dd class="files">
-          {% for file in row.files|slice(0,1) %}
-            <a class="cd-button cd-button--icon cd-button--small cd-button--icon-no-margin" href="{{ file.url }}" title="{{ file.name }}">
-              <span class="visually-hidden">{{ 'Download'|t }}</span>
-              <svg class="cd-icon cd-icon--copyurl" aria-hidden="true" focusable="false" width="16" height="16"><use xlink:href="#cd-icon--copyurl"></use></svg>
-            </a>
-          {% endfor %}
-          {% if row.files|length > 1 %}
-            <em>&nbsp;+ {{ row.files|length - 1 }} more</em>
-          {% endif %}
-        </dd>
-      </div>
+      <dt class="files">{{ 'Files'|t }}:</dt>
+      <dd class="files">
+        {% for file in row.files|slice(0,1) %}
+          <a class="cd-button cd-button--icon cd-button--small cd-button--icon-no-margin" href="{{ file.url }}" title="{{ file.name }}">
+            <span class="visually-hidden">{{ 'Download'|t }}</span>
+            <svg class="cd-icon cd-icon--copyurl" aria-hidden="true" focusable="false" width="16" height="16"><use xlink:href="#cd-icon--copyurl"></use></svg>
+          </a>
+        {% endfor %}
+        {% if row.files|length > 1 %}
+          <em>&nbsp;+ {{ row.files|length - 1 }} more</em>
+        {% endif %}
+      </dd>
       {% endif %}
     </dl>
   </footer>


### PR DESCRIPTION
fix: remove divs around description list items so the intended layout takes effect

Refs: RWR-154

Expected results:
![Selection_065](https://user-images.githubusercontent.com/1835923/173839423-88d119be-c697-4f49-9ce4-40eeb925ef70.png)

