### PR TITLE
[RWR-164] River meta layout fix

### DIFF
--- a/html/themes/custom/common_design_subtheme/components/hri-river/hri-river.css
+++ b/html/themes/custom/common_design_subtheme/components/hri-river/hri-river.css
@@ -109,6 +109,12 @@
   padding: 0;
   font-size: var(--cd-font-size--small);
 }
+/* unset cd-typography defaults for dl tag */
+@media screen and (min-width: 576px) {
+  .hri-river__result dl.meta {
+    display: block;
+  }
+}
 .hri-river__result .meta div {
   display: inline;
   white-space: nowrap;

--- a/html/themes/custom/common_design_subtheme/components/hri-river/hri-river.css
+++ b/html/themes/custom/common_design_subtheme/components/hri-river/hri-river.css
@@ -135,7 +135,7 @@
   margin: 0 0.5rem;
   content: "•";
 }
-.hri-river__result .meta div:last-of-type dd::after {
+.hri-river__result .meta dd:last-of-type::after {
   content: none;
 }
 


### PR DESCRIPTION
# RWR-164

I can't find the cause of the bug, but in prod we're seeing `cd-typography` defaults applying to RW Rivers, but it doesn't happen on dev/local. I suppose there might be some combo of Paragraphs on the affected page but at any rate, I've added an explicit override.

I also removed the trailing bullet.