### PR TITLE
[RWR-142] Add/change some icons

### DIFF
--- a/html/themes/custom/common_design_subtheme/components/hri-river/hri-river.css
+++ b/html/themes/custom/common_design_subtheme/components/hri-river/hri-river.css
@@ -168,12 +168,22 @@
   text-decoration: none;
 }
 .hri-river__file-icon {
+  position: relative;
+  top: 1px;
   display: inline-block;
   width: 12px;
   height: 12px;
   background: transparent url("rw-icons-sprite.svg") -72px -60px no-repeat;
+}
+
+/* external URL symbols */
+.hri-river__external-url {
   position: relative;
   top: 1px;
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  background: transparent url("rw-icons-sprite.svg") -84px -108px no-repeat;
 }
 
 /**

--- a/html/themes/custom/common_design_subtheme/components/hri-river/hri-river.css
+++ b/html/themes/custom/common_design_subtheme/components/hri-river/hri-river.css
@@ -164,8 +164,16 @@
 }
 
 /* files buttons */
-.hri-river__result .cd-button--small .cd-icon {
-  margin: 0;
+.hri-river__file {
+  text-decoration: none;
+}
+.hri-river__file-icon {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  background: transparent url("rw-icons-sprite.svg") -72px -60px no-repeat;
+  position: relative;
+  top: 1px;
 }
 
 /**

--- a/html/themes/custom/common_design_subtheme/templates/river-row.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/river-row.html.twig
@@ -55,9 +55,9 @@
       <dt class="files">{{ 'Files'|t }}:</dt>
       <dd class="files">
         {% for file in row.files|slice(0,1) %}
-          <a class="cd-button cd-button--icon cd-button--small cd-button--icon-no-margin" href="{{ file.url }}" title="{{ file.name }}">
+          <a class="hri-river__file" href="{{ file.url }}" title="{{ file.name }}">
             <span class="visually-hidden">{{ 'Download'|t }}</span>
-            <svg class="cd-icon cd-icon--copyurl" aria-hidden="true" focusable="false" width="16" height="16"><use xlink:href="#cd-icon--copyurl"></use></svg>
+            <span class="hri-river__file-icon"></span>
           </a>
         {% endfor %}
         {% if row.files|length > 1 %}

--- a/html/themes/custom/common_design_subtheme/templates/river-row.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/river-row.html.twig
@@ -15,7 +15,10 @@
         + {{ row.countries|slice(1)|length }} more
       {% endif %}
     </p>
-    <h3 class="title"><a href="{{ row.url }}">{{ row.title }}</a></h3>
+    <h3 class="title">
+      <a href="{{ row.url }}">{{ row.title }}</a>
+      <span class="hri-river__external-url"></span>
+    </h3>
   </header>
 
   <div class="content">


### PR DESCRIPTION
# RWR-142

All Rivers (no matter what datasource) now feature an External Link icon near the title, and a Download icon for the files that can be downloaded.

<img width="733" alt="Screen Shot 2022-07-25 at 13 51 29" src="https://user-images.githubusercontent.com/254753/180771681-a93c8138-5938-4e7d-9611-daec08d6f115.png">

