### PR TITLE
[RWR-177] Address Check1st audit results

### DIFF
--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
@@ -5,6 +5,7 @@ global-styling:
   js:
     js/login_destination.js: {}
   dependencies:
+    - common_design_subtheme/rw-brand
     - common_design_subtheme/hri-breadcrumbs
     - common_design_subtheme/hri-cd-header
     - common_design_subtheme/hri-global-styling
@@ -165,6 +166,8 @@ rw-river:
     theme:
       components/rw-river/rw-river.css: {}
       components/rw-river/rw-river-views.css: {}
+  dependencies:
+    - common_design_subtheme/rw-brand
 
 rw-river-letter-navigation:
   css:
@@ -173,3 +176,5 @@ rw-river-letter-navigation:
   js:
     components/rw-river-letter-navigation/rw-river-create-letter-navigation.js: {}
     components/rw-river-letter-navigation/rw-river-letter-navigation.js: {}
+  dependencies:
+    - common_design_subtheme/rw-brand

--- a/html/themes/custom/common_design_subtheme/components/hri-button/hri-button.css
+++ b/html/themes/custom/common_design_subtheme/components/hri-button/hri-button.css
@@ -9,19 +9,13 @@
 }
 
 .cd-button--light {
-  color: var(--cd-white);
-  background-color: var(--brand-secondary);
+  color: var(--cd-primary-color--dark);
+  background-color: var(--cd-primary-color--lighter);
 }
-.cd-button--light:hover {
-  color: var(--cd-white);
-  background-color: var(--brand-secondary);
-  background-image: linear-gradient(rgba(255, 255, 255, 0.0625), rgba(255, 255, 255, 0.0625));
-}
+.cd-button--light:hover,
 .cd-button--light:focus {
-  color: var(--cd-white);
-  border-color: black;
-  background-color: var(--brand-secondary);
-  background-image: linear-gradient(rgba(255, 255, 255, 0.0625), rgba(255, 255, 255, 0.0625));
+  color: var(--cd-primary-color--dark);
+  background-color: var(--cd-primary-color--light);
 }
 
 .cd-button--icon.cd-button--small.cd-button--icon-no-margin span + svg {

--- a/html/themes/custom/common_design_subtheme/css/brand.css
+++ b/html/themes/custom/common_design_subtheme/css/brand.css
@@ -15,4 +15,18 @@
   --brand-light: #d4e5f7;
   --brand-grey: var(--cd-blue-grey);
   --brand-logo-width: 150px;
+
+  --cd-ie-primary-color: #0988bb;
+  --cd-ie-primary-color--light: #63cef8;
+  --cd-ie-primary-color--dark: #032b3a;
+  --cd-ie-primary-color--lighter: #8fdbfa;
+  --cd-ie-highlight-red: #f65c51;
+  --cd-ie-highlight-red--light: #f88981;
+  --cd-primary-color-h: 197;
+  --cd-primary-color-s: 91%;
+  --cd-primary-color-l: 38%;
+  --cd-primary-color: hsl(var(--cd-primary-color-h),var(--cd-primary-color-s),var(--cd-primary-color-l));
+  --cd-primary-color--light: hsl(var(--cd-primary-color-h),var(--cd-primary-color-s),calc(var(--cd-primary-color-l) + 30%));
+  --cd-primary-color--dark: hsl(var(--cd-primary-color-h),var(--cd-primary-color-s),calc(var(--cd-primary-color-l) - 26%));
+  --cd-primary-color--lighter: hsl(var(--cd-primary-color-h),var(--cd-primary-color-s),calc(var(--cd-primary-color-l) + 39%));
 }

--- a/html/themes/custom/common_design_subtheme/css/brand.css
+++ b/html/themes/custom/common_design_subtheme/css/brand.css
@@ -11,7 +11,7 @@
   --brand-primary--dark: #04415a;
   --brand-secondary: #f65c51;
   --brand-secondary--dark: #eb1405;
-  --brand-highlight: var(--cd-blue--bright);
+  --brand-highlight: var(--cd-reliefweb-brand-red--dark);
   --brand-light: #d4e5f7;
   --brand-grey: var(--cd-blue-grey);
   --brand-logo-width: 150px;

--- a/html/themes/custom/common_design_subtheme/templates/hr-paragraphs-iframe.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/hr-paragraphs-iframe.html.twig
@@ -13,7 +13,7 @@
     'hri-iframe--' ~ ratio,
   ]
 %}
-<div class="{{ classes|join(' ') }}">
+<div{{ create_attribute().addClass(classes) }}>
   <iframe
     class="hri-iframe__iframe"
     sandbox="allow-scripts allow-same-origin"
@@ -25,6 +25,7 @@
     referrerpolicy="no-referrer"
     frameborder="0"
     target="_blank"
-    src="{{ embed_url }}">
+    src="{{ embed_url }}"
+    title="{{ 'Embedded media'|t }}">
   </iframe>
 </div>


### PR DESCRIPTION
# RWR-177

1. OCHA Services "See All" button now matches RW branding and has contrast of 9:1
2. iframes now output "Embedded media" as title in all cases. If we wanted to customize I'd add a new field to the paragraph but in the mean time at least it announces something
3. We do intentionally have `alt=""` on our River results when a preview image is available. As noted in the ticket this does seem to be best practice but I assume the tool can't divine that with certainty and has to call it out.

@left23 I tagged you since you're familiar with test results and my normal approver is 🌴  — no need to load it up locally, we can look on dev or have Check1st do another audit after deploying.