### PR TITLE
[multi-ticket] Mobile fixes

### DIFF
--- a/config/image.style.highlight_thumb.yml
+++ b/config/image.style.highlight_thumb.yml
@@ -10,6 +10,6 @@ effects:
     id: image_scale_and_crop
     weight: 1
     data:
-      width: 410
-      height: 205
+      width: 480
+      height: 240
       anchor: center-top

--- a/html/themes/custom/common_design_subtheme/components/hri-card-list/hri-card-list.css
+++ b/html/themes/custom/common_design_subtheme/components/hri-card-list/hri-card-list.css
@@ -14,14 +14,15 @@
 
 .paragraph--type--card-list .field--name-field-paragraphs {
   --hri-card-list-num-cols: 1;
+  --hri-card-list-gap-size: 1rem;
 
   display: flex;
   flex-flow: row wrap;
-  gap: 1rem;
+  gap: var(--hri-card-list-gap-size);
 }
 
 .paragraph--type--card-list .field--name-field-paragraphs .field__item {
-  flex: 1 1 calc((100% / var(--hri-card-list-num-cols)) - (1rem * var(--hri-card-list-num-cols) - 1rem));
+  flex: 1 1 calc((100% / var(--hri-card-list-num-cols)) - (var(--hri-card-list-gap-size) * (var(--hri-card-list-num-cols) - 1)));
 }
 
 @media screen and (min-width: 480px) {

--- a/html/themes/custom/common_design_subtheme/components/hri-card-list/hri-card-list.css
+++ b/html/themes/custom/common_design_subtheme/components/hri-card-list/hri-card-list.css
@@ -13,7 +13,7 @@
 }
 
 .paragraph--type--card-list .field--name-field-paragraphs {
-  --hri-card-list-num-cols: 2;
+  --hri-card-list-num-cols: 1;
 
   display: flex;
   flex-flow: row wrap;
@@ -21,5 +21,11 @@
 }
 
 .paragraph--type--card-list .field--name-field-paragraphs .field__item {
-  flex: 0 1 calc((100% / var(--hri-card-list-num-cols)) - (1rem * var(--hri-card-list-num-cols) - 1rem));
+  flex: 1 1 calc((100% / var(--hri-card-list-num-cols)) - (1rem * var(--hri-card-list-num-cols) - 1rem));
+}
+
+@media screen and (min-width: 480px) {
+  .paragraph--type--card-list .field--name-field-paragraphs {
+    --hri-card-list-num-cols: 2;
+  }
 }

--- a/html/themes/custom/common_design_subtheme/components/hri-heading/hri-heading.css
+++ b/html/themes/custom/common_design_subtheme/components/hri-heading/hri-heading.css
@@ -8,19 +8,20 @@
  * @see html/themes/custom/common_design_subtheme/templates/paragraph--landing-page--heading.html.twig
  */
 .heading--with-link {
-  position: relative;
+  display: flex;
+  flex-flow: row wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 2rem;
+}
+
+.heading--with-link .field--name-field-title {
+  margin-bottom: 0;
 }
 
 .heading--with-link .field-title__link {
-  position: absolute;
-  top: 10px;
+  font-size: 1rem;
   font-style: italic;
-}
-
-@media screen and (min-width: 1024px) {
-  .heading--with-link .field-title__link {
-    top: 16px;
-  }
 }
 
 .heading--with-link .field-title__link:hover {


### PR DESCRIPTION
# RWR-181 / RWR-183

The homepage had two paragraph types with mobile bugs:

- Heading with Link had overlapping text. That's impossible now because it's a flexbox that wraps when space doesn't permit.
- Card List was 2-col within all viewport sizes. It's now 1-col until space permits, and I cleaned it up a little to permit easier customization in other situations. Updated the "Heading Thumbnail" image size to match our CSS breakpoint.