### PR TITLE
[RWR-166] label change for HDX filters

### DIFF
--- a/html/modules/custom/hr_paragraphs/src/Controller/HdxController.php
+++ b/html/modules/custom/hr_paragraphs/src/Controller/HdxController.php
@@ -363,7 +363,7 @@ class HdxController extends ControllerBase {
    */
   public function getHdxFilters($key = NULL) {
     $filters = [
-      'groups' => $this->t('Groups'),
+      'groups' => $this->t('Locations'),
       'res_format' => $this->t('Formats'),
       'organization' => $this->t('Organizations'),
       'vocab_Topics' => $this->t('Tags'),


### PR DESCRIPTION
# RWR-166

Label change for HDX filters. I left the machine key as `groups`.