### PR TITLE
[RWR-186] display RW document title/text fields in Editor previews

### DIFF
--- a/config/core.entity_view_display.paragraph.reliefweb_document.preview.yml
+++ b/config/core.entity_view_display.paragraph.reliefweb_document.preview.yml
@@ -10,6 +10,7 @@ dependencies:
     - paragraphs.paragraphs_type.reliefweb_document
   module:
     - link
+    - text
 id: paragraph.reliefweb_document.preview
 targetEntityType: paragraph
 bundle: reliefweb_document
@@ -25,8 +26,21 @@ content:
       rel: ''
       target: ''
     third_party_settings: {  }
+    weight: 2
+    region: content
+  field_text:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_title:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
     weight: 0
     region: content
-hidden:
-  field_text: true
-  field_title: true
+hidden: {  }

--- a/html/modules/custom/hr_paragraphs/templates/hr-paragraphs-rw-list.html.twig
+++ b/html/modules/custom/hr_paragraphs/templates/hr-paragraphs-rw-list.html.twig
@@ -1,4 +1,4 @@
-<div class="river">
+<div class="river hr-paragraphs-rw-list">
   <div class="river__results">
     {% for row in data %}
       <article class="river__result" data-rw-id="{{ row.id }}">


### PR DESCRIPTION
# RWR-186

Display `field_title`/`field_text` in editor previews of RW Document para type.