### PR TITLE
fix: title margins for Editor previews

### DIFF
--- a/html/themes/custom/hri_admin/css/admin.css
+++ b/html/themes/custom/hri_admin/css/admin.css
@@ -27,8 +27,8 @@
 }
 
 .field--name-field-paragraphs .field--name-field-title {
-  margin-block-start: 1em;
-  font-size: 2em;
+  margin: 1rem 0;
+  font-size: 1.75em;
 }
 
 .river__result {


### PR DESCRIPTION
In the comments Marina asked if the RW URL could be nudged away from the title.

Refs: RWR-181
