### PR TITLE
[RWR-193] Chrome can recognize SVG favicon now

### DIFF
--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
@@ -22,7 +22,7 @@ function common_design_subtheme_preprocess_html(&$vars) {
     'rel' => 'alternate icon',
     'href' => '/' . $theme_path . '/favicon.ico',
     'type' => 'image/vnd.microsoft.icon',
-    'sizes' => 'all',
+    'sizes' => 'any',
   ];
 
   // Construct a <link> for our SVG favicon.


### PR DESCRIPTION
# RWR-193

Firefox was dealing with our markup just fine. Chrome needed some attention. The observable side-effect is the dark-mode favicon. It's black on grey before checking the PR out, then (after a cache-clear) it will be white on grey:

<img width="255" alt="Screen Shot 2022-08-11 at 16 04 51" src="https://user-images.githubusercontent.com/254753/184152067-cf289c4f-4cc6-4438-ad0d-e8b22dfd33ca.png">