### PR TITLE
[RWR-191] apply markup filtering to Basic HTML

### DIFF
--- a/config/filter.format.basic_html.yml
+++ b/config/filter.format.basic_html.yml
@@ -13,7 +13,7 @@ filters:
   filter_html:
     id: filter_html
     provider: filter
-    status: false
+    status: true
     weight: -10
     settings:
       allowed_html: '<a href hreflang> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <p> <br> <span> <img src alt height width data-entity-type data-entity-uuid data-align data-caption>'


### PR DESCRIPTION
This will strip word processor styles and enforce more consistency between various pages, regardless of how the content is entered or where it comes from.

Refs: RWR-191