### PR TITLE
[RWR-196] API-driven Key Figures paragraph

### DIFF
--- a/config/core.entity_form_display.paragraph.reliefweb_key_figures.default.yml
+++ b/config/core.entity_form_display.paragraph.reliefweb_key_figures.default.yml
@@ -1,0 +1,49 @@
+uuid: 8fe5a5ff-1897-45d7-a1de-8fb1608124ae
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.reliefweb_key_figures.field_country
+    - field.field.paragraph.reliefweb_key_figures.field_max_number_of_items
+    - field.field.paragraph.reliefweb_key_figures.field_text
+    - field.field.paragraph.reliefweb_key_figures.field_title
+    - paragraphs.paragraphs_type.reliefweb_key_figures
+  module:
+    - text
+id: paragraph.reliefweb_key_figures.default
+targetEntityType: paragraph
+bundle: reliefweb_key_figures
+mode: default
+content:
+  field_country:
+    type: options_select
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_max_number_of_items:
+    type: number
+    weight: 3
+    region: content
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+  field_text:
+    type: text_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_title:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/config/core.entity_view_display.paragraph.reliefweb_key_figures.default.yml
+++ b/config/core.entity_view_display.paragraph.reliefweb_key_figures.default.yml
@@ -1,0 +1,35 @@
+uuid: 444b76c0-5279-4350-acb0-dc06a5da9a35
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.reliefweb_key_figures.field_country
+    - field.field.paragraph.reliefweb_key_figures.field_max_number_of_items
+    - field.field.paragraph.reliefweb_key_figures.field_text
+    - field.field.paragraph.reliefweb_key_figures.field_title
+    - paragraphs.paragraphs_type.reliefweb_key_figures
+  module:
+    - text
+id: paragraph.reliefweb_key_figures.default
+targetEntityType: paragraph
+bundle: reliefweb_key_figures
+mode: default
+content:
+  field_text:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_title:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  field_country: true
+  field_max_number_of_items: true

--- a/config/field.field.group.cluster.field_paragraphs.yml
+++ b/config/field.field.group.cluster.field_paragraphs.yml
@@ -30,51 +30,54 @@ settings:
     negate: 1
     target_bundles_drag_drop:
       card_list:
-        weight: -33
+        weight: -35
         enabled: false
       child_groups:
-        weight: -24
-        enabled: true
-      featured_highlight:
-        weight: -30
-        enabled: false
-      group_pages:
-        weight: -23
-        enabled: false
-      hdx_river:
-        weight: -29
-        enabled: false
-      heading:
-        weight: -28
-        enabled: false
-      iframe:
-        weight: -27
-        enabled: false
-      layout:
         weight: -26
         enabled: true
-      menu_block:
+      featured_highlight:
+        weight: -32
+        enabled: false
+      group_pages:
         weight: -25
         enabled: false
+      hdx_river:
+        weight: -31
+        enabled: false
+      heading:
+        weight: -30
+        enabled: false
+      iframe:
+        weight: -29
+        enabled: false
+      layout:
+        weight: -28
+        enabled: true
+      menu_block:
+        weight: -27
+        enabled: false
       reliefweb_document:
+        weight: -24
+        enabled: false
+      reliefweb_key_figures:
         weight: -22
         enabled: false
       reliefweb_river:
-        weight: -21
+        weight: -23
         enabled: false
       rss_feed:
-        weight: -20
+        weight: -21
         enabled: false
       table_of_contents:
-        weight: -19
+        weight: -20
         enabled: false
       text_block:
-        weight: -32
+        weight: -34
         enabled: false
       twitter_feed:
-        weight: -18
+        weight: -19
         enabled: true
       upcoming_events:
-        weight: -31
+        weight: -33
         enabled: false
 field_type: entity_reference_revisions

--- a/config/field.field.group.operation.field_paragraphs.yml
+++ b/config/field.field.group.operation.field_paragraphs.yml
@@ -28,51 +28,54 @@ settings:
     negate: 1
     target_bundles_drag_drop:
       card_list:
-        weight: -33
+        weight: -35
         enabled: false
       child_groups:
-        weight: -24
+        weight: -26
         enabled: false
       featured_highlight:
-        weight: -30
+        weight: -32
         enabled: false
       group_pages:
-        weight: -23
-        enabled: false
-      hdx_river:
-        weight: -29
-        enabled: false
-      heading:
-        weight: -28
-        enabled: false
-      iframe:
-        weight: -27
-        enabled: false
-      layout:
-        weight: -26
-        enabled: true
-      menu_block:
         weight: -25
         enabled: false
+      hdx_river:
+        weight: -31
+        enabled: false
+      heading:
+        weight: -30
+        enabled: false
+      iframe:
+        weight: -29
+        enabled: false
+      layout:
+        weight: -28
+        enabled: true
+      menu_block:
+        weight: -27
+        enabled: false
       reliefweb_document:
+        weight: -24
+        enabled: false
+      reliefweb_key_figures:
         weight: -22
         enabled: false
       reliefweb_river:
-        weight: -21
+        weight: -23
         enabled: false
       rss_feed:
-        weight: -20
+        weight: -21
         enabled: false
       table_of_contents:
-        weight: -19
+        weight: -20
         enabled: false
       text_block:
-        weight: -32
+        weight: -34
         enabled: false
       twitter_feed:
-        weight: -18
+        weight: -19
         enabled: true
       upcoming_events:
-        weight: -31
+        weight: -33
         enabled: false
 field_type: entity_reference_revisions

--- a/config/field.field.node.landing_page.field_paragraphs.yml
+++ b/config/field.field.node.landing_page.field_paragraphs.yml
@@ -34,51 +34,54 @@ settings:
     negate: 1
     target_bundles_drag_drop:
       card_list:
-        weight: -33
+        weight: -35
         enabled: false
       child_groups:
-        weight: -24
-        enabled: true
-      featured_highlight:
-        weight: -30
-        enabled: false
-      group_pages:
-        weight: -23
-        enabled: true
-      hdx_river:
-        weight: -29
-        enabled: false
-      heading:
-        weight: -28
-        enabled: false
-      iframe:
-        weight: -27
-        enabled: false
-      layout:
         weight: -26
         enabled: true
-      menu_block:
+      featured_highlight:
+        weight: -32
+        enabled: false
+      group_pages:
         weight: -25
+        enabled: true
+      hdx_river:
+        weight: -31
+        enabled: false
+      heading:
+        weight: -30
+        enabled: false
+      iframe:
+        weight: -29
+        enabled: false
+      layout:
+        weight: -28
+        enabled: true
+      menu_block:
+        weight: -27
         enabled: false
       reliefweb_document:
+        weight: -24
+        enabled: false
+      reliefweb_key_figures:
         weight: -22
         enabled: false
       reliefweb_river:
-        weight: -21
+        weight: -23
         enabled: false
       rss_feed:
-        weight: -20
+        weight: -21
         enabled: false
       table_of_contents:
-        weight: -19
+        weight: -20
         enabled: false
       text_block:
-        weight: -32
+        weight: -34
         enabled: false
       twitter_feed:
-        weight: -18
+        weight: -19
         enabled: true
       upcoming_events:
-        weight: -31
+        weight: -33
         enabled: true
 field_type: entity_reference_revisions

--- a/config/field.field.node.landing_page.field_paragraphs_secondary.yml
+++ b/config/field.field.node.landing_page.field_paragraphs_secondary.yml
@@ -36,51 +36,54 @@ settings:
     negate: 1
     target_bundles_drag_drop:
       card_list:
-        weight: -33
+        weight: -35
         enabled: true
       child_groups:
-        weight: -24
-        enabled: true
-      featured_highlight:
-        weight: -30
-        enabled: false
-      group_pages:
-        weight: -23
-        enabled: true
-      hdx_river:
-        weight: -29
-        enabled: false
-      heading:
-        weight: -28
-        enabled: false
-      iframe:
-        weight: -27
-        enabled: false
-      layout:
         weight: -26
         enabled: true
-      menu_block:
+      featured_highlight:
+        weight: -32
+        enabled: false
+      group_pages:
         weight: -25
+        enabled: true
+      hdx_river:
+        weight: -31
+        enabled: false
+      heading:
+        weight: -30
+        enabled: false
+      iframe:
+        weight: -29
+        enabled: false
+      layout:
+        weight: -28
+        enabled: true
+      menu_block:
+        weight: -27
         enabled: false
       reliefweb_document:
+        weight: -24
+        enabled: false
+      reliefweb_key_figures:
         weight: -22
         enabled: false
       reliefweb_river:
-        weight: -21
+        weight: -23
         enabled: false
       rss_feed:
-        weight: -20
+        weight: -21
         enabled: false
       table_of_contents:
-        weight: -19
+        weight: -20
         enabled: false
       text_block:
-        weight: -32
+        weight: -34
         enabled: false
       twitter_feed:
-        weight: -18
+        weight: -19
         enabled: true
       upcoming_events:
-        weight: -31
+        weight: -33
         enabled: true
 field_type: entity_reference_revisions

--- a/config/field.field.node.page.field_paragraphs.yml
+++ b/config/field.field.node.page.field_paragraphs.yml
@@ -28,51 +28,54 @@ settings:
     negate: 1
     target_bundles_drag_drop:
       card_list:
-        weight: -33
+        weight: -35
         enabled: false
       child_groups:
-        weight: -24
+        weight: -26
         enabled: false
       featured_highlight:
-        weight: -30
+        weight: -32
         enabled: false
       group_pages:
-        weight: -23
-        enabled: false
-      hdx_river:
-        weight: -29
-        enabled: false
-      heading:
-        weight: -28
-        enabled: false
-      iframe:
-        weight: -27
-        enabled: false
-      layout:
-        weight: -26
-        enabled: true
-      menu_block:
         weight: -25
         enabled: false
+      hdx_river:
+        weight: -31
+        enabled: false
+      heading:
+        weight: -30
+        enabled: false
+      iframe:
+        weight: -29
+        enabled: false
+      layout:
+        weight: -28
+        enabled: true
+      menu_block:
+        weight: -27
+        enabled: false
       reliefweb_document:
+        weight: -24
+        enabled: false
+      reliefweb_key_figures:
         weight: -22
         enabled: false
       reliefweb_river:
-        weight: -21
+        weight: -23
         enabled: false
       rss_feed:
-        weight: -20
+        weight: -21
         enabled: false
       table_of_contents:
-        weight: -19
+        weight: -20
         enabled: false
       text_block:
-        weight: -32
+        weight: -34
         enabled: false
       twitter_feed:
-        weight: -18
+        weight: -19
         enabled: true
       upcoming_events:
-        weight: -31
+        weight: -33
         enabled: false
 field_type: entity_reference_revisions

--- a/config/field.field.paragraph.reliefweb_key_figures.field_country.yml
+++ b/config/field.field.paragraph.reliefweb_key_figures.field_country.yml
@@ -1,0 +1,21 @@
+uuid: 9da65864-c534-4f0e-b6de-3c0ab472668b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_country
+    - paragraphs.paragraphs_type.reliefweb_key_figures
+  module:
+    - options
+id: paragraph.reliefweb_key_figures.field_country
+field_name: field_country
+entity_type: paragraph
+bundle: reliefweb_key_figures
+label: Country
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/field.field.paragraph.reliefweb_key_figures.field_max_number_of_items.yml
+++ b/config/field.field.paragraph.reliefweb_key_figures.field_max_number_of_items.yml
@@ -1,0 +1,23 @@
+uuid: c7437000-0c07-4255-a1c8-ffd92d5e2790
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_max_number_of_items
+    - paragraphs.paragraphs_type.reliefweb_key_figures
+id: paragraph.reliefweb_key_figures.field_max_number_of_items
+field_name: field_max_number_of_items
+entity_type: paragraph
+bundle: reliefweb_key_figures
+label: 'Max number of items'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: 1
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/config/field.field.paragraph.reliefweb_key_figures.field_text.yml
+++ b/config/field.field.paragraph.reliefweb_key_figures.field_text.yml
@@ -1,0 +1,21 @@
+uuid: 5be7aede-dfed-430e-b9f2-e296e7dde9c5
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_text
+    - paragraphs.paragraphs_type.reliefweb_key_figures
+  module:
+    - text
+id: paragraph.reliefweb_key_figures.field_text
+field_name: field_text
+entity_type: paragraph
+bundle: reliefweb_key_figures
+label: Text
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/config/field.field.paragraph.reliefweb_key_figures.field_title.yml
+++ b/config/field.field.paragraph.reliefweb_key_figures.field_title.yml
@@ -1,0 +1,19 @@
+uuid: 8876e53c-cfde-4a0a-9f0d-49e891ea985c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_title
+    - paragraphs.paragraphs_type.reliefweb_key_figures
+id: paragraph.reliefweb_key_figures.field_title
+field_name: field_title
+entity_type: paragraph
+bundle: reliefweb_key_figures
+label: Title
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.storage.paragraph.field_country.yml
+++ b/config/field.storage.paragraph.field_country.yml
@@ -1,0 +1,105 @@
+uuid: a0e56712-3bf9-4735-ac71-0494e6a7741f
+langcode: en
+status: true
+dependencies:
+  module:
+    - options
+    - paragraphs
+id: paragraph.field_country
+field_name: field_country
+entity_type: paragraph
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: AFG
+      label: Afghanistan
+    -
+      value: BDI
+      label: Burundi
+    -
+      value: BFA
+      label: 'Burkina Faso'
+    -
+      value: BGD
+      label: Bangladesh
+    -
+      value: CAF
+      label: 'Central African Republic'
+    -
+      value: CMR
+      label: Cameroon
+    -
+      value: COD
+      label: 'Congo, Democratic Republic of the'
+    -
+      value: COL
+      label: Colombia
+    -
+      value: ETH
+      label: Ethiopia
+    -
+      value: HTI
+      label: Haiti
+    -
+      value: IRQ
+      label: Iraq
+    -
+      value: KEN
+      label: Kenya
+    -
+      value: LBN
+      label: Lebanon
+    -
+      value: LBY
+      label: Libya
+    -
+      value: MLI
+      label: Mali
+    -
+      value: MMR
+      label: Myanmar
+    -
+      value: MOZ
+      label: Mozambique
+    -
+      value: NER
+      label: Niger
+    -
+      value: NGA
+      label: Nigeria
+    -
+      value: PSE
+      label: 'Palestine, State of'
+    -
+      value: SDN
+      label: Sudan
+    -
+      value: SOM
+      label: Somalia
+    -
+      value: SSD
+      label: 'South Sudan'
+    -
+      value: SYR
+      label: 'Syrian Arab Republic'
+    -
+      value: TCD
+      label: Chad
+    -
+      value: UKR
+      label: Ukraine
+    -
+      value: VEN
+      label: 'Venezuela (Bolivarian Republic of)'
+    -
+      value: YEM
+      label: Yemen
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.paragraph.field_iframe_url.yml
+++ b/config/field.storage.paragraph.field_iframe_url.yml
@@ -3,14 +3,14 @@ langcode: en
 status: true
 dependencies:
   module:
-    - hr_paragraphs
+    - link
     - paragraphs
 id: paragraph.field_iframe_url
 field_name: field_iframe_url
 entity_type: paragraph
-type: long_link
+type: link
 settings: {  }
-module: hr_paragraphs
+module: link
 locked: false
 cardinality: 1
 translatable: true

--- a/config/paragraphs.paragraphs_type.reliefweb_key_figures.yml
+++ b/config/paragraphs.paragraphs_type.reliefweb_key_figures.yml
@@ -1,0 +1,10 @@
+uuid: 5f604541-cbb7-4700-8989-bbd83b2dd1ed
+langcode: en
+status: true
+dependencies: {  }
+id: reliefweb_key_figures
+label: 'ReliefWeb - Key Figures'
+icon_uuid: null
+icon_default: null
+description: ''
+behavior_plugins: {  }

--- a/html/modules/custom/hr_paragraphs/hr_paragraphs.module
+++ b/html/modules/custom/hr_paragraphs/hr_paragraphs.module
@@ -44,6 +44,14 @@ function hr_paragraphs_theme($existing, $type, $theme, $path) {
         'view_all' => NULL,
       ],
     ],
+    'hr_paragraphs_rw_key_figures' => [
+      'template' => 'hr-paragraphs-rw-key-figures',
+      'variables' => [
+        'data' => [],
+        'total' => [],
+        'view_all' => NULL,
+      ],
+    ],
     'upcoming_events' => [
       'template' => 'upcoming-events',
       'variables' => [
@@ -956,6 +964,35 @@ function hr_paragraphs_preprocess_paragraph__reliefweb_document(&$variables) {
     '#data' => [$doc],
     '#total' => NULL,
     '#view_all' => NULL,
+    '#weight' => 99,
+  ];
+}
+
+/**
+ * Implements hook_preprocess_paragraph__type().
+ */
+function hr_paragraphs_preprocess_paragraph__reliefweb_key_figures(&$variables) {
+  /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
+  $paragraph = $variables['paragraph'];
+
+  // Make sure Country is set.
+  if (!$paragraph->hasField('field_country') || $paragraph->field_country->isEmpty()) {
+    return;
+  }
+
+  // Fetch country from user input.
+  $key_figures_country = $paragraph->field_country->value;
+
+  // Set max number of items to 5 by default.
+  $max_number_of_items = $paragraph->field_max_number_of_items->value ?? 5;
+
+  /** @var \Drupal\hr_paragraphs\Controller\KeyFiguresController */
+  $key_figures_controller = \Drupal::service('hr_paragraphs.key_figures_controller');
+  $results = $key_figures_controller->getKeyFigures($key_figures_country);
+
+  $variables['content']['key_figures'] = [
+    '#theme' => 'hr_paragraphs_rw_key_figures',
+    '#data' => $key_figures_controller->buildKeyFigures($results, $max_number_of_items),
     '#weight' => 99,
   ];
 }

--- a/html/modules/custom/hr_paragraphs/hr_paragraphs.services.yml
+++ b/html/modules/custom/hr_paragraphs/hr_paragraphs.services.yml
@@ -14,6 +14,9 @@ services:
   hr_paragraphs.rss_controller:
     class: \Drupal\hr_paragraphs\Controller\RssController
     arguments: ['@http_client']
+  hr_paragraphs.key_figures_controller:
+    class: \Drupal\hr_paragraphs\Controller\KeyFiguresController
+    arguments: ['@http_client']
   hr_paragraphs.breadcrumb.groupcontent:
     class: 'Drupal\hr_paragraphs\Breadcrumb\GroupContentBreadcrumbBuilder'
     tags:

--- a/html/modules/custom/hr_paragraphs/src/Controller/KeyFiguresController.php
+++ b/html/modules/custom/hr_paragraphs/src/Controller/KeyFiguresController.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Drupal\hr_paragraphs\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use GuzzleHttp\ClientInterface;
+
+/**
+ * Page controller for Key Figures.
+ */
+class KeyFiguresController extends ControllerBase {
+
+  /**
+   * The HTTP client to fetch the files with.
+   *
+   * @var \GuzzleHttp\ClientInterface
+   */
+  protected $httpClient;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(ClientInterface $http_client) {
+    $this->httpClient = $http_client;
+  }
+
+  /**
+   * Fetch Key Figures.
+   *
+   * @param string $iso3
+   *   ISO3 of the country we want Key Figures for.
+   *
+   * @return array<string, mixed>
+   *   Raw results.
+   */
+  public function getKeyFigures(string $iso3) : array {
+    $endpoint = 'https://raw.githubusercontent.com/reliefweb/crisis-app-data/v2/edition/world/countries/';
+
+    // Construct full URL.
+    $fullUrl = $endpoint . $iso3 . '/figures.json';
+
+    try {
+      $response = $this->httpClient->request(
+        'GET',
+        $fullUrl,
+      );
+    }
+    catch (RequestException $exception) {
+      if ($exception->getCode() === 404) {
+        throw new NotFoundHttpException();
+      }
+      else {
+        throw $exception;
+      }
+    }
+
+    $body = $response->getBody() . '';
+    $results = json_decode($body, TRUE);
+
+    return $results;
+  }
+
+  /**
+   * Build reliefweb objects.
+   *
+   * @param array<string, mixed> $results
+   *   Raw results from API.
+   * @param int $max
+   *   Number of items to return.
+   *
+   * @return array<string, mixed>
+   *   Results.
+   */
+  public function buildKeyFigures(array $results, int $max) : array {
+    $data = [];
+
+    foreach ($results as $row) {
+      $title = $row['name'];
+      // Basic info for Key Figure.
+      $data[$title] = [
+        'title' => $title,
+        'date' => $row['date'],
+        'url' => $row['url'],
+        'value' => $row['value'],
+        'source' => $row['source'],
+      ];
+
+      // Sparklines can also be constructed using the `values` array.
+      // @see https://github.com/UN-OCHA/rwint9-site/blob/develop/html/modules/custom/reliefweb_key_figures/src/Services/KeyFiguresClient.php#L249-L254
+    }
+
+    // Limit to the number specified by Editor, then return.
+    return array_slice($data, 0, $max);
+  }
+
+}

--- a/html/modules/custom/hr_paragraphs/templates/hr-paragraphs-rw-key-figures.html.twig
+++ b/html/modules/custom/hr_paragraphs/templates/hr-paragraphs-rw-key-figures.html.twig
@@ -1,0 +1,21 @@
+<div class="hr-paragraphs-rw-key-figures key-figures">
+  <ul class="key-figures__results">
+    {% for row in data %}
+      <li class="key-figure">
+        <figure>
+          <figcaption>{{ row.title }}</figcaption>
+          <div class="key-figure__content">
+            <strong class="key-figure__value">{{ row.value }}</strong>
+          </div>
+          <footer>
+            <time datetime="{{ row.date }}">Updated {{ row.date|date('d M Y') }}</time>
+            <cite>
+              <span class="visually-hidden">Source:</span>
+              <a href="{{ row.url }}">{{ row.source }}</a>
+            </cite>
+          </footer>
+        </figure>
+      </li>
+    {% endfor %}
+  </ul>
+</div>{# .key-figures #}

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
@@ -166,6 +166,11 @@ rw-country:
   dependencies:
     - common_design_subtheme/rw-brand
 
+rw-key-figures:
+  css:
+    theme:
+      components/rw-key-figures/rw-key-figures.css: {}
+
 rw-river:
   css:
     theme:

--- a/html/themes/custom/common_design_subtheme/components/rw-key-figures/rw-key-figures.css
+++ b/html/themes/custom/common_design_subtheme/components/rw-key-figures/rw-key-figures.css
@@ -1,0 +1,145 @@
+/* stylelint-disable max-line-length */
+/**
+ * RW Key Figures component
+ *
+ * If you want to modify this component, add an overrides file without touching
+ * this file, which we source directly from RW D9.
+ *
+ * @see https://github.com/UN-OCHA/rwint9-site/blob/8900b2b7079594a59a8ccc2c75c4c7f1415eef3a/html/themes/custom/common_design_subtheme/components/rw-key-figures/rw-key-figures.css
+ */
+
+/* Country key figures */
+.rw-key-figures h3 {
+  margin-bottom: 20px;
+}
+.rw-key-figures ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  line-height: 1.5;
+}
+.rw-key-figures li:after {
+  display: table;
+  clear: both;
+  content: "";
+}
+.rw-key-figures figure {
+  width: 100%;
+  margin: 0 0 20px 0;
+  padding: 16px;
+  border: 1px solid var(--cd-reliefweb-brand-grey--light);
+}
+.rw-key-figures figure figcaption {
+  margin: 0 0 20px 0;
+  font-size: 17px;
+  font-weight: bold;
+  font-style: normal;
+}
+.rw-key-figures figure p {
+  display: inline-block;
+  margin: 0 12px 10px 0;
+  vertical-align: middle;
+}
+.rw-key-figures figure data {
+  display: block;
+  color: var(--cd-reliefweb-brand-blue--dark);
+  font-size: 22px;
+  font-weight: bold;
+}
+.rw-key-figures figure small {
+  display: block;
+  margin-top: 6px;
+  font-size: 13px;
+  font-style: normal;
+  line-height: 1.5;
+}
+.rw-key-figures figure svg {
+  float: right;
+  overflow: visible;
+  width: 120px;
+  padding: 10px 0;
+  opacity: 0.5;
+  fill: none;
+  stroke: var(--cd-reliefweb-brand-grey--dark);
+  stroke-width: 2px;
+}
+.rw-key-figures figure footer {
+  clear: both;
+  margin-top: 10px;
+  font-size: 14px;
+}
+.rw-key-figures figure time {
+  display: inline-block;
+  margin: 0 12px 0 0;
+  padding: 1px 6px;
+  vertical-align: middle;
+  border-radius: 5px;
+  background: var(--cd-reliefweb-grey--disable);
+}
+.rw-key-figures figure.recent time:before {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  margin: -2px 6px 0 0;
+  content: "";
+  vertical-align: middle;
+  border-radius: 6px;
+  background: var(--cd-reliefweb-brand-red--dark);
+}
+.rw-key-figures figure cite {
+  float: right;
+  padding: 1px 6px;
+  color: white;
+  border-radius: 5px;
+  background: var(--cd-reliefweb-brand-blue--dark);
+  font-style: normal;
+}
+.rw-key-figures figure cite a {
+  color: inherit;
+}
+
+.rw-key-figures__links a {
+  display: inline;
+}
+.rw-key-figures__links a + a:before {
+  display: block;
+  margin-top: 16px;
+  content: "";
+}
+
+@media screen {
+  .rw-key-figures ul {
+    display: grid;
+    grid-template-columns: repeat(1, 1fr);
+    grid-column-gap: 20px;
+  }
+  .rw-key-figures ul li {
+    display: flex;
+    margin: 0;
+  }
+  .rw-key-figures ul li figure {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+  }
+  .rw-key-figures figure div {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .rw-key-figures figure footer {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+  }
+  .rw-key-figures figure small span {
+    display: block;
+  }
+}
+
+@media screen and (min-width: 450px) {
+  .rw-key-figures ul {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}

--- a/html/themes/custom/common_design_subtheme/templates/hr-paragraphs-rw-key-figures.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/hr-paragraphs-rw-key-figures.html.twig
@@ -1,0 +1,25 @@
+{{ attach_library('common_design_subtheme/rw-key-figures') }}
+
+<div class="rw-key-figures">
+  <ul class="rw-key-figures__list">
+    {% for row in data %}
+      <li class="key-figure">
+        <figure class="rw-key-figures__figure rw-key-figures__figure--standard">
+          <figcaption class="rw-key-figures__figure__label">{{ row.title }}</figcaption>
+          <div class="rw-key-figures__figure__content">
+            <p>
+              <data value="{{ row.value }}" class="rw-key-figures__figure__value">{{ row.value }}</data>
+            </p>
+          </div>
+          <footer class="rw-key-figures__figure__footer">
+            <time class="rw-key-figures__figure__updated" datetime="{{ row.date }}">Updated {{ row.date|date('d M Y') }}</time>
+            <cite class="rw-key-figures__figure__source">
+              <span class="visually-hidden">Source:</span>
+              <a href="{{ row.url }}">{{ row.source }}</a>
+            </cite>
+          </footer>
+        </figure>
+      </li>
+    {% endfor %}
+  </ul>
+</div>{# .rw-key-figures #}


### PR DESCRIPTION
# RWR-196

Place the Paragraph and pick a country from the list (and optionally a max number of items). It should render more or less like ReliefWeb. Notable differences:

- Commas are missing from Key Figure number
- Sparklines are missing. I saw how they can be constructed but omitted it to build this MVP in one day.
- "No change since" dates also omitted. The data exists in the source, just needs to be added to `buildKeyFigures()`

<img width="796" alt="Screen Shot 2022-08-19 at 15 35 46" src="https://user-images.githubusercontent.com/254753/185630623-ea8128b3-a25d-4f94-84c4-6aca5bb5efb4.png">
