### PR TITLE
[RWR-219] add Help text to Featured Highlights

### DIFF
--- a/config/core.entity_form_display.paragraph.featured_highlight.default.yml
+++ b/config/core.entity_form_display.paragraph.featured_highlight.default.yml
@@ -39,7 +39,7 @@ content:
     weight: 1
     region: content
     settings:
-      rows: 5
+      rows: 3
       placeholder: ''
     third_party_settings: {  }
   field_title:

--- a/config/field.field.paragraph.featured_highlight.field_image.yml
+++ b/config/field.field.paragraph.featured_highlight.field_image.yml
@@ -12,7 +12,7 @@ field_name: field_image
 entity_type: paragraph
 bundle: featured_highlight
 label: Image
-description: ''
+description: '<strong>Image will be displayed 480×240 (a 2:1 aspect ratio).</strong> If necessary the source image will be cropped from the bottom, so that the top portion is guaranteed to be visible.'
 required: true
 translatable: false
 default_value: {  }
@@ -24,7 +24,7 @@ settings:
   file_extensions: 'png gif jpg jpeg'
   max_filesize: ''
   max_resolution: ''
-  min_resolution: ''
+  min_resolution: 480x240
   alt_field: true
   alt_field_required: true
   title_field: false

--- a/config/field.field.paragraph.featured_highlight.field_text.yml
+++ b/config/field.field.paragraph.featured_highlight.field_text.yml
@@ -12,7 +12,7 @@ field_name: field_text
 entity_type: paragraph
 bundle: featured_highlight
 label: Text
-description: ''
+description: 'When displayed, this Text field will end at the last full sentence before the 280 character limit.'
 required: true
 translatable: false
 default_value: {  }

--- a/html/themes/custom/common_design_subtheme/templates/paragraph--featured-highlight.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraph--featured-highlight.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Default theme implementation to display a paragraph.
+ * Default theme implementation to display a Featured Highlight paragraph.
  *
  * @overrides html/themes/custom/common_design_subtheme/templates/paragraph.html.twig
  *

--- a/html/themes/custom/hri_admin/css/admin.css
+++ b/html/themes/custom/hri_admin/css/admin.css
@@ -3,6 +3,16 @@
  */
 
 /**
+ * We use CD components occasionally, so declare any CSS Custom Props we might
+ * need to use.
+ */
+:root {
+  --cd-gray--dark: #144372;
+  --cd-blue--bright: #82b5e9;
+}
+
+
+/**
  * Large images in WYSIWYG
  *
  * When large images get initially uploaded to the WYSIWYG editor, it's possible

--- a/html/themes/custom/hri_admin/hri_admin.libraries.yml
+++ b/html/themes/custom/hri_admin/hri_admin.libraries.yml
@@ -2,3 +2,5 @@ global-styling:
   css:
     theme:
       css/admin.css: {}
+  dependencies:
+    - common_design/cd-alert

--- a/html/themes/custom/hri_admin/templates/text-format-wrapper.html.twig
+++ b/html/themes/custom/hri_admin/templates/text-format-wrapper.html.twig
@@ -1,0 +1,39 @@
+{#
+/**
+ * @file
+ * Theme override for a text format-enabled form element.
+ *
+ * @overrides html/core/themes/seven/templates/classy/content-edit/text-format-wrapper.html.twig
+ *
+ * Available variables:
+ * - children: Text format element children.
+ * - description: Text format element description.
+ * - attributes: HTML attributes for the containing element.
+ * - aria_description: Flag for whether or not an ARIA description has been
+ *   added to the description container.
+ *
+ * @see template_preprocess_text_format_wrapper()
+ */
+#}
+{{ attach_library('common_design/cd-alert') }}
+
+<div class="text-format-wrapper form-item">
+  {{ children }}
+
+  <div class="cd-alert">
+    <div aria-live="polite">
+      <div class="cd-alert__container cd-max-width [ cd-flow ]">
+        <div class="cd-alert__message">
+          {% if description %}
+            {%
+              set classes = [
+                aria_description ? 'description',
+              ]
+            %}
+            <div{{ attributes.addClass(classes) }}>{{ description }}</div>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
<img width="1161" alt="Screen Shot 2022-09-08 at 11 55 10" src="https://user-images.githubusercontent.com/254753/189096770-200e9476-f755-4aba-b6d7-b5051d27ce70.png">


Refs: RWR-219