### PR TITLE
[RWR-220] improve display of Key Figures

### DIFF
--- a/html/modules/custom/hr_paragraphs/hr_paragraphs.module
+++ b/html/modules/custom/hr_paragraphs/hr_paragraphs.module
@@ -49,6 +49,8 @@ function hr_paragraphs_theme($existing, $type, $theme, $path) {
     'hr_paragraphs_rw_key_figures' => [
       'template' => 'hr-paragraphs-rw-key-figures',
       'variables' => [
+        'country_iso' => NULL,
+        'country_name' => NULL,
         'data' => [],
         'total' => [],
         'view_all' => NULL,
@@ -1045,8 +1047,11 @@ function hr_paragraphs_preprocess_paragraph__reliefweb_key_figures(&$variables) 
   // Fetch country from user input.
   $key_figures_country = $paragraph->field_country->value;
 
-  // Set max number of items to 5 by default.
-  $max_number_of_items = $paragraph->field_max_number_of_items->value ?? 5;
+  // Fetch label of the user input.
+  $key_figures_country_labels = $paragraph->getFieldDefinition('field_country')->getFieldStorageDefinition()->getSetting('allowed_values');
+
+  // Set max number of items to 4 by default.
+  $max_number_of_items = $paragraph->field_max_number_of_items->value ?? 4;
 
   /** @var \Drupal\hr_paragraphs\Controller\KeyFiguresController */
   $key_figures_controller = \Drupal::service('hr_paragraphs.key_figures_controller');
@@ -1054,6 +1059,8 @@ function hr_paragraphs_preprocess_paragraph__reliefweb_key_figures(&$variables) 
 
   $variables['content']['key_figures'] = [
     '#theme' => 'hr_paragraphs_rw_key_figures',
+    '#country_iso' => $key_figures_country,
+    '#country_name' => $key_figures_country_labels[$key_figures_country],
     '#data' => $key_figures_controller->buildKeyFigures($results, $max_number_of_items),
     '#weight' => 99,
     '#cache' => [

--- a/html/modules/custom/hr_paragraphs/src/Controller/KeyFiguresController.php
+++ b/html/modules/custom/hr_paragraphs/src/Controller/KeyFiguresController.php
@@ -83,25 +83,230 @@ class KeyFiguresController extends ControllerBase {
    *   Results.
    */
   public function buildKeyFigures(array $results, int $max) : array {
-    $data = [];
+    $figures = [];
+    $figures = $this->parseKeyFigures($results);
 
-    foreach ($results as $row) {
-      $title = $row['name'];
-      // Basic info for Key Figure.
-      $data[$title] = [
-        'title' => $title,
-        'date' => $row['date'],
-        'url' => $row['url'],
-        'value' => $row['value'],
-        'source' => $row['source'],
-      ];
-
-      // Sparklines can also be constructed using the `values` array.
-      // @see https://github.com/UN-OCHA/rwint9-site/blob/develop/html/modules/custom/reliefweb_key_figures/src/Services/KeyFiguresClient.php#L249-L254
+    // Add the trend and sparkline.
+    foreach ($figures as $index => $figure) {
+      $figure['trend'] = $this->getKeyFigureTrend($figure['values']);
+      $figure['sparkline'] = $this->getKeyFigureSparkline($figure['values']);
+      $figures[$index] = $figure;
     }
 
     // Limit to the number specified by Editor, then return.
-    return array_slice($data, 0, $max);
+    return array_slice($figures, 0, $max);
+  }
+
+  /**
+   * Parse the Key figures data, validating and sorting the figures.
+   *
+   * @param array $figures
+   *   Figures data from the API.
+   *
+   * @return array
+   *   Array of figures data prepared for display perserving the order but
+   *   putting the "recent" ones at the top. Each figure contains the title,
+   *   figure, formatted update date, source with a url to the latest source
+   *   document and the value history to build the sparkline and the trend.
+   */
+  protected function parseKeyFigures(array $figures) {
+    // Maximum number of days since the last update to still consider the
+    // figure as recent.
+    $number_of_days = 7;
+    $now = new \DateTime();
+    $recent = [];
+    $standard = [];
+    $options = ['options' => ['min_range' => 0]];
+
+    foreach ($figures as $item) {
+      // Validate url.
+      if (empty($item['url']) || !filter_var($item['url'], FILTER_VALIDATE_URL)) {
+        continue;
+      }
+
+      // Validate name.
+      if (empty($item['name']) || ctype_space($item['name'])) {
+        continue;
+      }
+      $item['name'] = trim($item['name']);
+
+      // Validate value (integer > 0).
+      // Currently, the key figures are for population in need etc. so there is
+      // no interest in showing a card with a value of '0' so we skip it.
+      if (empty($item['value']) || !filter_var($item['value'], FILTER_VALIDATE_INT, $options)) {
+        continue;
+      }
+      $item['value'] = (int) $item['value'];
+
+      // Validate date.
+      $item['date'] = !empty($item['date']) ? date_create($item['date']) : FALSE;
+      if ($item['date'] === FALSE) {
+        continue;
+      }
+
+      // Validate source.
+      if (empty($item['source']) || ctype_space($item['source'])) {
+        continue;
+      }
+      $item['source'] = trim($item['source']);
+
+      // Validate list of past figures.
+      if (empty($item['values']) || !is_array($item['values'])) {
+        continue;
+      }
+
+      // Sanitize and sort the past figures for the sparkline and trend.
+      $values = [];
+      foreach ($item['values'] as $value) {
+        // A value of '0' is acceptable to construct the sparkline as opposed
+        // to the main figure so we don't use 'empty()'.
+        if (!isset($value['value'], $value['date']) || !filter_var($value['value'], FILTER_VALIDATE_INT, $options)) {
+          continue;
+        }
+        $date = date_create($value['date']);
+        // Skip if the date is invalid.
+        if ($date === FALSE) {
+          continue;
+        }
+        $iso = $date->format('c');
+        // Skip if there is already a more recent value for the same date.
+        if (!isset($values[$iso])) {
+          $values[$iso] = [
+            'value' => (int) $value['value'],
+            'date' => $date,
+          ];
+        }
+      }
+      // Sort the past values by newest first.
+      krsort($values);
+      $item['values'] = $values;
+
+      // Set the figure status and format its date.
+      $item['status'] = 'standard';
+      $days_ago = $item['date']->diff($now)->days;
+
+      if ($days_ago < $number_of_days) {
+        $item['status'] = 'recent';
+        if ($days_ago === 0) {
+          $item['updated'] = $this->t('Updated today');
+        }
+        elseif ($days_ago === 1) {
+          $item['updated'] = $this->t('Updated yesterday');
+        }
+        else {
+          $item['updated'] = $this->t('Updated @days days ago', [
+            '@days' => $days_ago,
+          ]);
+        }
+        $recent[] = $item;
+      }
+      else {
+        $item['updated'] = $this->t('Updated @date', [
+          '@date' => $item['date']->format('j M Y'),
+        ]);
+        $standard[] = $item;
+      }
+    }
+
+    // Preserve the figures order but put recently updated first.
+    return array_merge($recent, $standard);
+  }
+
+  /**
+   * Get the sparkline data for the given key figure history values.
+   *
+   * @param array $values
+   *   Key figure history values.
+   */
+  protected function getKeyFigureSparkline(array $values) {
+    if (empty($values)) {
+      return NULL;
+    }
+
+    // Find max and min values.
+    $numbers = array_column($values, 'value');
+    $max = max($numbers);
+    $min = min($numbers);
+
+    // Skip if there was no change.
+    if ($max === $min) {
+      return NULL;
+    }
+
+    // The values are ordered by newest first. We retrieve the number of
+    // days between the newest and oldest days for the x axis.
+    $last = reset($values)['date'];
+    $oldest = end($values)['date'];
+    $span = $last->diff($oldest)->days;
+    if ($span == 0) {
+      return NULL;
+    }
+
+    // View box dimensions for the sparkline.
+    $height = 40;
+    $width = 120;
+
+    // Calculate the coordinates of each value.
+    $points = [];
+    foreach ($values as $value) {
+      $diff = $oldest->diff($value['date'])->days;
+      $x = ($width / $span) * $diff;
+      $y = $height - ((($value['value'] - $min) / ($max - $min)) * $height);
+      $points[] = round($x, 2) . ',' . round($y, 2);
+    }
+
+    $sparkline = [
+      'points' => $points,
+    ];
+
+    return $sparkline;
+  }
+
+  /**
+   * Get the trend data for the given key figure history values.
+   *
+   * @param array $values
+   *   Key figure history values.
+   */
+  protected function getKeyFigureTrend(array $values) {
+    if (count($values) < 2) {
+      return NULL;
+    }
+
+    // The values are ordered by newest first. We want the 2 most recent values
+    // to compute the trend.
+    $first = reset($values);
+    $second = next($values);
+
+    if ($second['value'] === 0) {
+      $percentage = 100;
+    }
+    else {
+      $percentage = (int) round((1 - $first['value'] / $second['value']) * 100);
+    }
+
+    if ($percentage === 0) {
+      $message = $this->t('No change');
+    }
+    elseif ($percentage < 0) {
+      $message = $this->t('@percentage% increase', [
+        '@percentage' => abs($percentage),
+      ]);
+    }
+    else {
+      $message = $this->t('@percentage% decrease', [
+        '@percentage' => abs($percentage),
+      ]);
+    }
+
+    $trend = [
+      'message' => $message,
+      'since' => $this->t('since @date', [
+        '@date' => $second['date']->format('j M Y'),
+      ]),
+    ];
+
+    return $trend;
   }
 
 }

--- a/html/modules/custom/hr_paragraphs/templates/hr-paragraphs-rw-key-figures.html.twig
+++ b/html/modules/custom/hr_paragraphs/templates/hr-paragraphs-rw-key-figures.html.twig
@@ -29,11 +29,6 @@
   </ul>
 
   <footer class="view-more rw-key-figures__links">
-    {% if more %}
-    <a href="{{ url('<current>', {}, {'query': {'figures': 'all'}, 'fragment': id}) }}">{{ 'View all @country figures'|t({'@country': country}) }}</a>
-    {% endif %}
-    {% if dataset %}
-    <a href="{{ dataset.url }}" target="_blank" rel="noopener">{{ dataset.title }}</a>
-    {% endif %}
+    <a href="https://reliefweb.int/country/{{ country }}#key-figures">{{ 'View all figures'|t }}</a>
   </footer>
 </div>{# .key-figures #}

--- a/html/modules/custom/hr_paragraphs/templates/hr-paragraphs-rw-key-figures.html.twig
+++ b/html/modules/custom/hr_paragraphs/templates/hr-paragraphs-rw-key-figures.html.twig
@@ -1,21 +1,39 @@
+{{ attach_library('common_design_subtheme/rw-key-figures') }}
+
 <div class="hr-paragraphs-rw-key-figures key-figures">
-  <ul class="key-figures__results">
-    {% for row in data %}
-      <li class="key-figure">
-        <figure>
-          <figcaption>{{ row.title }}</figcaption>
-          <div class="key-figure__content">
-            <strong class="key-figure__value">{{ row.value }}</strong>
-          </div>
-          <footer>
-            <time datetime="{{ row.date }}">Updated {{ row.date|date('d M Y') }}</time>
-            <cite>
-              <span class="visually-hidden">Source:</span>
-              <a href="{{ row.url }}">{{ row.source }}</a>
-            </cite>
-          </footer>
-        </figure>
-      </li>
+  <ul class="rw-key-figures__list">
+    {% for figure in data %}
+    <li>
+      <figure class="rw-key-figures__figure rw-key-figures__figure--{{ figure.status }}">
+        <figcaption class="rw-key-figures__figure__label">{{ figure.name }}</figcaption>
+        <div class="rw-key-figures__figure__content">
+          <p>
+            <data value="{{ figure.value }}" class="rw-key-figures__figure__value">{{ figure.value|number_format }}</data>
+            {% if figure.trend %}
+              <small class="rw-key-figures__figure__trend"><span class="rw-key-figures__figure__trend__message">{{ figure.trend.message }}</span> <span class="rw-key-figures__figure__trend__since">{{ figure.trend.since }}</span></small>
+            {% endif %}
+          </p>
+          {% if figure.sparkline %}
+          <svg viewBox="0 0 120 40" xmlns="http://www.w3.org/2000/svg" width="120" fill="none" stroke="#999" aria-hidden="true">
+            <polyline points="{{ figure.sparkline.points|join(' ') }}"/>
+          </svg>
+          {% endif %}
+        </div>
+        <footer class="rw-key-figures__figure__footer">
+          <time datetime="{{ figure.date|date('c') }}" class="rw-key-figures__figure__updated">{{ figure.updated }}</time>
+          <cite class="rw-key-figures__figure__source"><span class="visually-hidden">{{ 'Source: '|t }} </span><a href="{{ figure.url }}">{{ figure.source }}</a></cite>
+        </footer>
+      </figure>
+    </li>
     {% endfor %}
   </ul>
+
+  <footer class="view-more rw-key-figures__links">
+    {% if more %}
+    <a href="{{ url('<current>', {}, {'query': {'figures': 'all'}, 'fragment': id}) }}">{{ 'View all @country figures'|t({'@country': country}) }}</a>
+    {% endif %}
+    {% if dataset %}
+    <a href="{{ dataset.url }}" target="_blank" rel="noopener">{{ dataset.title }}</a>
+    {% endif %}
+  </footer>
 </div>{# .key-figures #}

--- a/html/themes/custom/common_design_subtheme/components/hri-global-styling/hri-global-styling.css
+++ b/html/themes/custom/common_design_subtheme/components/hri-global-styling/hri-global-styling.css
@@ -36,3 +36,27 @@
   height: 12px;
   background: transparent url("../rw-brand/rw-icons-sprite.svg") -84px -108px no-repeat;
 }
+
+/**
+ * View more
+ */
+.view-more {
+  width: 100%;
+  text-align: center;
+}
+
+.view-more a {
+  font-size: var(--cd-font-size--small);
+  font-style: italic;
+}
+
+.view-more a:after {
+  display: inline-block;
+  overflow: hidden;
+  width: 12px;
+  height: 12px;
+  margin: 0 0 0 6px;
+  content: "";
+  vertical-align: middle;
+  background: transparent url("../rw-brand/rw-icons-sprite.svg") -84px -108px no-repeat;
+}

--- a/html/themes/custom/common_design_subtheme/templates/hr-paragraphs-rw-key-figures.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/hr-paragraphs-rw-key-figures.html.twig
@@ -29,11 +29,6 @@
   </ul>
 
   <footer class="view-more rw-key-figures__links">
-    {% if more %}
-    <a href="{{ url('<current>', {}, {'query': {'figures': 'all'}, 'fragment': id}) }}">{{ 'View all @country figures'|t({'@country': country}) }}</a>
-    {% endif %}
-    {% if dataset %}
-    <a href="{{ dataset.url }}" target="_blank" rel="noopener">{{ dataset.title }}</a>
-    {% endif %}
+    <a href="https://reliefweb.int/country/{{ country_iso|lower }}?figures=all#key-figures">{{ 'View all @country figures'|t({'@country': country_name}) }}</a>
   </footer>
 </div>{# .rw-key-figures #}

--- a/html/themes/custom/common_design_subtheme/templates/hr-paragraphs-rw-key-figures.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/hr-paragraphs-rw-key-figures.html.twig
@@ -2,24 +2,38 @@
 
 <div class="rw-key-figures">
   <ul class="rw-key-figures__list">
-    {% for row in data %}
-      <li class="key-figure">
-        <figure class="rw-key-figures__figure rw-key-figures__figure--standard">
-          <figcaption class="rw-key-figures__figure__label">{{ row.title }}</figcaption>
-          <div class="rw-key-figures__figure__content">
-            <p>
-              <data value="{{ row.value }}" class="rw-key-figures__figure__value">{{ row.value|number_format(0, '.', ',') }}</data>
-            </p>
-          </div>
-          <footer class="rw-key-figures__figure__footer">
-            <time class="rw-key-figures__figure__updated" datetime="{{ row.date }}">Updated {{ row.date|date('d M Y') }}</time>
-            <cite class="rw-key-figures__figure__source">
-              <span class="visually-hidden">Source:</span>
-              <a href="{{ row.url }}">{{ row.source }}</a>
-            </cite>
-          </footer>
-        </figure>
-      </li>
+    {% for figure in data %}
+    <li>
+      <figure class="rw-key-figures__figure rw-key-figures__figure--{{ figure.status }}">
+        <figcaption class="rw-key-figures__figure__label">{{ figure.name }}</figcaption>
+        <div class="rw-key-figures__figure__content">
+          <p>
+            <data value="{{ figure.value }}" class="rw-key-figures__figure__value">{{ figure.value|number_format }}</data>
+            {% if figure.trend %}
+              <small class="rw-key-figures__figure__trend"><span class="rw-key-figures__figure__trend__message">{{ figure.trend.message }}</span> <span class="rw-key-figures__figure__trend__since">{{ figure.trend.since }}</span></small>
+            {% endif %}
+          </p>
+          {% if figure.sparkline %}
+          <svg viewBox="0 0 120 40" xmlns="http://www.w3.org/2000/svg" width="120" fill="none" stroke="#999" aria-hidden="true">
+            <polyline points="{{ figure.sparkline.points|join(' ') }}"/>
+          </svg>
+          {% endif %}
+        </div>
+        <footer class="rw-key-figures__figure__footer">
+          <time datetime="{{ figure.date|date('c') }}" class="rw-key-figures__figure__updated">{{ figure.updated }}</time>
+          <cite class="rw-key-figures__figure__source"><span class="visually-hidden">{{ 'Source: '|t }} </span><a href="{{ figure.url }}">{{ figure.source }}</a></cite>
+        </footer>
+      </figure>
+    </li>
     {% endfor %}
   </ul>
+
+  <footer class="view-more rw-key-figures__links">
+    {% if more %}
+    <a href="{{ url('<current>', {}, {'query': {'figures': 'all'}, 'fragment': id}) }}">{{ 'View all @country figures'|t({'@country': country}) }}</a>
+    {% endif %}
+    {% if dataset %}
+    <a href="{{ dataset.url }}" target="_blank" rel="noopener">{{ dataset.title }}</a>
+    {% endif %}
+  </footer>
 </div>{# .rw-key-figures #}

--- a/html/themes/custom/hri_admin/css/admin.css
+++ b/html/themes/custom/hri_admin/css/admin.css
@@ -26,11 +26,13 @@
   padding: 1rem;
 }
 
+/* Title */
 .field--name-field-paragraphs .field--name-field-title {
   margin: 1rem 0;
   font-size: 1.75em;
 }
 
+/* Rivers */
 .river__result {
   max-width: 720px;
 }
@@ -60,6 +62,7 @@
   padding-inline-end: 1rem;
 }
 
+/* Text */
 .paragraph--type--text-block .align-left {
   margin-right: 1rem;
 }
@@ -67,6 +70,7 @@
   margin-left: 1rem;
 }
 
+/* Card List */
 .paragraph--type--card-list .field--name-field-paragraphs {
   --hri-admin-card-list-num-cols: 2;
 
@@ -88,6 +92,7 @@
   content: "Destination: ";
 }
 
+/* Upcoming Events */
 .upcoming-events__list {
   /* layout */
   display: flex;
@@ -159,4 +164,32 @@
   border: dotted green;
   min-height: 30px;
   margin-bottom: 20px;
+}
+
+/* ReliefWeb Key Figures */
+.rw-key-figures__list {
+  --rwkf-num-cols: 1;
+  --rwkf-gap-size: 1rem;
+
+  display: flex;
+  flex-flow: row wrap;
+  gap: var(--rwkf-gap-size);
+  margin: 0;
+  padding: 0;
+}
+@media screen and (min-width: 768px) {
+  .rw-key-figures__list {
+    --rwkf-num-cols: 2;
+  }
+}
+.rw-key-figures__list > li {
+  display: block;
+  margin: 0;
+  padding: 0;
+  flex: 0 1 calc((100% / var(--rwkf-num-cols)) - (var(--rwkf-gap-size) * (var(--rwkf-num-cols) - 1)));
+  border: 2px solid #0003;
+}
+.rw-key-figures__figure__label {
+  font-weight: 700;
+  font-size: 1.25em;
 }


### PR DESCRIPTION
- Add the “No change since” and last-updated date to each Key Figure
- Display the sparklines
- Add a link to RW crisis figures section of the relevant country page

<img width="775" alt="Screen Shot 2022-09-08 at 15 43 54" src="https://user-images.githubusercontent.com/254753/189138178-90a9dc38-366e-46c4-9648-441a2e41dfe3.png">
