### PR TITLE
RWR-257 Two page layout for GCSE

### DIFF
--- a/config/core.entity_form_display.paragraph.search_results.default.yml
+++ b/config/core.entity_form_display.paragraph.search_results.default.yml
@@ -1,0 +1,23 @@
+uuid: 72caf9e5-77e6-4869-8c83-37cd42039669
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.search_results.field_gcse_id
+    - paragraphs.paragraphs_type.search_results
+id: paragraph.search_results.default
+targetEntityType: paragraph
+bundle: search_results
+mode: default
+content:
+  field_gcse_id:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/config/core.entity_view_display.paragraph.search_results.default.yml
+++ b/config/core.entity_view_display.paragraph.search_results.default.yml
@@ -1,0 +1,21 @@
+uuid: 595ba67f-ee69-4aac-932a-a8bcc31ea5b8
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.search_results.field_gcse_id
+    - paragraphs.paragraphs_type.search_results
+id: paragraph.search_results.default
+targetEntityType: paragraph
+bundle: search_results
+mode: default
+content:
+  field_gcse_id:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden: {  }

--- a/config/field.field.paragraph.search_results.field_gcse_id.yml
+++ b/config/field.field.paragraph.search_results.field_gcse_id.yml
@@ -1,0 +1,19 @@
+uuid: 763fcdd6-4fe4-4784-8459-4144b0fd2f46
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_gcse_id
+    - paragraphs.paragraphs_type.search_results
+id: paragraph.search_results.field_gcse_id
+field_name: field_gcse_id
+entity_type: paragraph
+bundle: search_results
+label: 'GCSE ID'
+description: 'The ID value <code>cse.js?cx=ID</code>'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.storage.paragraph.field_gcse_id.yml
+++ b/config/field.storage.paragraph.field_gcse_id.yml
@@ -1,0 +1,21 @@
+uuid: 499f0953-6675-440a-999f-e9bda42dbb16
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_gcse_id
+field_name: field_gcse_id
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/paragraphs.paragraphs_type.search_results.yml
+++ b/config/paragraphs.paragraphs_type.search_results.yml
@@ -1,0 +1,10 @@
+uuid: 9ac2d6bd-9c6a-4418-aba5-06fa52df4b9e
+langcode: en
+status: true
+dependencies: {  }
+id: search_results
+label: 'Search results'
+icon_uuid: null
+icon_default: null
+description: 'Search results from Google Custom Search Engine'
+behavior_plugins: {  }

--- a/html/themes/custom/common_design_subtheme/components/google-cse/google-cse.css
+++ b/html/themes/custom/common_design_subtheme/components/google-cse/google-cse.css
@@ -6,10 +6,10 @@
  * we can override them.
  */
 
-div#___gcse_0 {
+/* div#___gcse_0 {
   position: relative;
   max-height: var(--cd-site-header-height);
-}
+} */
 
 .gsc-adBlock {
   display: none !important;
@@ -74,14 +74,14 @@ form.gsc-search-box {
   margin: 0 auto;
 }
 
-.gsc-results-wrapper-visible {
+/* .gsc-results-wrapper-visible {
   position: relative;
   top: -4px;
   padding-bottom: 1rem;
   border-bottom: 2px solid var(--brand-primary--light);
   background: #fff;
   box-shadow: 0 3px 8px #0002;
-}
+} */
 
 .gs-webResult.gs-result a.gs-title:link {
   color: var(--brand-primary--dark) !important;

--- a/html/themes/custom/common_design_subtheme/templates/cd/cd-header/cd-search.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/cd/cd-header/cd-search.html.twig
@@ -1,10 +1,23 @@
 <div class="cd-search">
   {{ attach_library('common_design_subtheme/google-cse') }}
 
-  <div class="search-block-form cd-search__form block block-search" data-drupal-selector="search-block-form" aria-labelledby="cd-search-form" data-cd-toggable="Search" data-cd-component="cd-search" data-cd-logo="search" data-cd-focus-target="cd-search" id="block-common-design-subtheme-searchform" role="search">
-    {# BEGIN Google embed code #}
-    <script async defer src="https://cse.google.com/cse.js?cx=673ecb0cc607a4bd6"></script>
-    <div class="gcse-search"></div>
-    {# END Google embed code #}
+  <div class="cd-search__form" aria-labelledby="cd-search-btn" data-cd-toggable="Search" data-cd-component="cd-search" data-cd-logo="search" data-cd-focus-target="cd-search" id="block-searchform" role="search">
+    <h2 class="visually-hidden">Search form</h2>
+    <form action="/search" method="get" accept-charset="UTF-8">
+      <div class="form--inline clearfix">
+        <div class="js-form-item form-item js-form-type-textfield form-type-textfield js-form-item-keys form-item-keys">
+          <label for="cd-search">Search</label>
+          <input placeholder="What are you looking for?" class="cd-search__input form-text" type="text" id="cd-search" name="q" value="{{ keyword }}" size="30" maxlength="128" autocomplete="off">
+        </div>
+        <div class="form-actions js-form-wrapper form-wrapper">
+          <button data-twig-suggestion="search_submit" class="cd-search__submit button js-form-submit form-submit" value="Search" type="submit">
+            <svg class="cd-icon cd-icon--search" width="16" height="16" aria-hidden="true" focusable="false">
+              <use xlink:href="#cd-icon--search"></use>
+            </svg>
+            <span class="visually-hidden">Search</span>
+          </button>
+        </div>
+      </div>
+    </form>
   </div>
 </div>

--- a/html/themes/custom/common_design_subtheme/templates/cd/cd-header/cd-search.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/cd/cd-header/cd-search.html.twig
@@ -2,11 +2,11 @@
   {{ attach_library('common_design_subtheme/google-cse') }}
 
   <div class="cd-search__form" aria-labelledby="cd-search-btn" data-cd-toggable="Search" data-cd-component="cd-search" data-cd-logo="search" data-cd-focus-target="cd-search" id="block-searchform" role="search">
-    <h2 class="visually-hidden">Search form</h2>
+    <h2 class="visually-hidden">{% trans %}Search form{% endtrans %}</h2>
     <form action="/search" method="get" accept-charset="UTF-8">
       <div class="form--inline clearfix">
         <div class="js-form-item form-item js-form-type-textfield form-type-textfield js-form-item-keys form-item-keys">
-          <label for="cd-search">Search</label>
+          <label for="cd-search">{% trans %}Search{% endtrans %}</label>
           <input placeholder="What are you looking for?" class="cd-search__input form-text" type="text" id="cd-search" name="q" value="{{ keyword }}" size="30" maxlength="128" autocomplete="off">
         </div>
         <div class="form-actions js-form-wrapper form-wrapper">

--- a/html/themes/custom/common_design_subtheme/templates/page.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/page.html.twig
@@ -4,6 +4,47 @@
     {% include '@common_design_subtheme/cd/cd-header/cd-header.html.twig' %}
   {% endblock %}
 
+  {% block main %}
+    {# Link to skip to the main content is in html.html.twig #}
+    <main role="main" {{ attributes.setAttribute('id', 'main-content').addClass(layout_classes) }}>
+
+      {{ page.page_title }}
+
+      <div class="cd-layout-content-wrapper">
+
+        {% if page.sidebar_first %}
+          {# We are using CSS pseudo class :empty to hide these aside elements if the region prints empty.
+            This means we cannot have any white space between tags (as below).
+            Attn: Having the twig debug enabled means the div is no longer empty.
+            See Drupal issues/953034 for description and current status.
+          #}
+          <aside class="cd-layout-sidebar-first" role="complementary">{{ page.sidebar_first }}</aside>
+        {% endif %}
+
+        <div class="cd-layout-content">
+          {{ page.content }}
+
+          {# BEGIN Google embed code #}
+          <script async defer src="https://cse.google.com/cse.js?cx=f1cb85d99bc304893"></script>
+          <div class="gcse-searchbox-only"></div>
+          {# END Google embed code #}
+
+          <div class="google-search-results">
+            <script async defer src="https://cse.google.com/cse.js?cx=f1cb85d99bc304893"></script>
+            <div class="gcse-searchresults-only"></div>
+          </div>
+
+        </div>
+        {# /.cd-layout-content #}
+
+        {% if page.sidebar_second %}
+          <aside class="cd-layout-sidebar-second" role="complementary">{{ page.sidebar_second }}</aside>
+        {% endif %}
+      </div>
+
+    </main>
+  {% endblock %}
+
   {% block footer %}
     {% include '@common_design_subtheme/cd/cd-footer/cd-footer.html.twig' %}
   {% endblock %}

--- a/html/themes/custom/common_design_subtheme/templates/page.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/page.html.twig
@@ -4,36 +4,6 @@
     {% include '@common_design_subtheme/cd/cd-header/cd-header.html.twig' %}
   {% endblock %}
 
-  {% block main %}
-    {# Link to skip to the main content is in html.html.twig #}
-    <main role="main" {{ attributes.setAttribute('id', 'main-content').addClass(layout_classes) }}>
-
-      {{ page.page_title }}
-
-      <div class="cd-layout-content-wrapper">
-
-        {% if page.sidebar_first %}
-          {# We are using CSS pseudo class :empty to hide these aside elements if the region prints empty.
-            This means we cannot have any white space between tags (as below).
-            Attn: Having the twig debug enabled means the div is no longer empty.
-            See Drupal issues/953034 for description and current status.
-          #}
-          <aside class="cd-layout-sidebar-first" role="complementary">{{ page.sidebar_first }}</aside>
-        {% endif %}
-
-        <div class="cd-layout-content">
-          {{ page.content }}
-        </div>
-        {# /.cd-layout-content #}
-
-        {% if page.sidebar_second %}
-          <aside class="cd-layout-sidebar-second" role="complementary">{{ page.sidebar_second }}</aside>
-        {% endif %}
-      </div>
-
-    </main>
-  {% endblock %}
-
   {% block footer %}
     {% include '@common_design_subtheme/cd/cd-footer/cd-footer.html.twig' %}
   {% endblock %}

--- a/html/themes/custom/common_design_subtheme/templates/page.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/page.html.twig
@@ -23,16 +23,6 @@
 
         <div class="cd-layout-content">
           {{ page.content }}
-
-          {# BEGIN Google embed code #}
-          <script async defer src="https://cse.google.com/cse.js?cx=f1cb85d99bc304893"></script>
-          <div class="gcse-searchbox-only"></div>
-          {# END Google embed code #}
-
-          <div class="google-search-results">
-            <div class="gcse-searchresults-only"></div>
-          </div>
-
         </div>
         {# /.cd-layout-content #}
 

--- a/html/themes/custom/common_design_subtheme/templates/page.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/page.html.twig
@@ -30,7 +30,6 @@
           {# END Google embed code #}
 
           <div class="google-search-results">
-            <script async defer src="https://cse.google.com/cse.js?cx=f1cb85d99bc304893"></script>
             <div class="gcse-searchresults-only"></div>
           </div>
 

--- a/html/themes/custom/common_design_subtheme/templates/paragraph--search-results.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraph--search-results.html.twig
@@ -3,7 +3,7 @@
  * @file
  * Default theme implementation to display a paragraph.
  *
- * @overrides html/modules/contrib/paragraphs/templates/paragraph.html.twig
+ * @overrides html/themes/custom/common_design_subtheme/templates/paragraph.html.twig
  *
  * Available variables:
  * - paragraph: Full paragraph entity.

--- a/html/themes/custom/common_design_subtheme/templates/paragraph--search-results.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraph--search-results.html.twig
@@ -50,7 +50,7 @@
 %}
 
 {{ attach_library('common_design_subtheme/google-cse') }}
-{% set gcseID = 'https://cse.google.com/cse.js?cx=' ~ paragraph.field_gcse_id.value %}
+{% set gcse_src = 'https://cse.google.com/cse.js?cx=' ~ paragraph.field_gcse_id.value %}
 
 {% block paragraph %}
   <div{{ attributes
@@ -61,7 +61,7 @@
     {% block content %}
 
       {# BEGIN Google embed code #}
-      <script async defer src="{{ gcseID }}"></script>
+      <script async defer src="{{ gcse_src }}"></script>
       <div class="gcse-searchbox-only"></div>
       {# END Google embed code #}
 

--- a/html/themes/custom/common_design_subtheme/templates/paragraph--search-results.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraph--search-results.html.twig
@@ -1,0 +1,74 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a paragraph.
+ *
+ * @overrides html/modules/contrib/paragraphs/templates/paragraph.html.twig
+ *
+ * Available variables:
+ * - paragraph: Full paragraph entity.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - paragraph.getCreatedTime() will return the paragraph creation timestamp.
+ *   - paragraph.id(): The paragraph ID.
+ *   - paragraph.bundle(): The type of the paragraph, for example, "image" or "text".
+ *   - paragraph.getOwnerId(): The user ID of the paragraph author.
+ *   See Drupal\paragraphs\Entity\Paragraph for a full list of public properties
+ *   and methods for the paragraph object.
+ * - content: All paragraph items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - paragraphs: The current template type (also known as a "theming hook").
+ *   - paragraphs--type-[type]: The current paragraphs type. For example, if the paragraph is an
+ *     "Image" it would result in "paragraphs--type--image". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - paragraphs--view-mode--[view_mode]: The View Mode of the paragraph; for example, a
+ *     preview would result in: "paragraphs--view-mode--preview", and
+ *     default: "paragraphs--view-mode--default".
+ * - view_mode: View mode; for example, "preview" or "full".
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_paragraph()
+ *
+ * @ingroup themeable
+ */
+#}
+{%
+  set classes = [
+    'paragraph',
+    'paragraph--type--' ~ paragraph.bundle|clean_class,
+    view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
+    not paragraph.isPublished() ? 'paragraph--unpublished',
+  ]
+%}
+
+{{ attach_library('common_design_subtheme/google-cse') }}
+{% set gcseID = 'https://cse.google.com/cse.js?cx=' ~ paragraph.field_gcse_id.value %}
+
+{% block paragraph %}
+  <div{{ attributes
+    .addClass(classes)
+    .setAttribute('data-type', paragraph.bundle)
+    .setAttribute('id', paragraph.bundle ~ '-' ~ paragraph.id())
+  }}>
+    {% block content %}
+
+      {# BEGIN Google embed code #}
+      <script async defer src="{{ gcseID }}"></script>
+      <div class="gcse-searchbox-only"></div>
+      {# END Google embed code #}
+
+      <div class="google-search-results">
+      <div class="gcse-searchresults-only"></div>
+      </div>
+
+    {% endblock %}
+  </div>
+{% endblock paragraph %}


### PR DESCRIPTION
Refs: RWR-257

### To test
- Check out branch and import config
- Create a new Node (I used Page type) and add the Search Results paragraph type with ID (see RWR-257)
- Set the Node's URL alias to `/search` if it isn't already
- Visit the homepage and do a search from the Global search in the header.

### Expected results
- The Search in the global header should look like the CD Search usually does
- The Search results page Search input (GCSE) should have brand colours for the search button

![Selection_179](https://user-images.githubusercontent.com/1835923/195597481-92728a41-e5a2-4ac3-875e-ac64f0b5f48e.png)


