### PR TITLE
[RWR-275] hri-iframe auto aspect-ratio now driven by JS

### DIFF
--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
@@ -114,6 +114,8 @@ hri-iframe:
   css:
     component:
       components/hri-iframe/hri-iframe.css: {}
+  js:
+    components/hri-iframe/hri-iframe.js: {}
 
 hri-layout:
   css:

--- a/html/themes/custom/common_design_subtheme/components/hri-iframe/hri-iframe.css
+++ b/html/themes/custom/common_design_subtheme/components/hri-iframe/hri-iframe.css
@@ -13,9 +13,8 @@
   aspect-ratio: 4 / 3;
 }
 
-.hri-iframe--ratio-auto {
-  aspect-ratio: calc(attr(data-width) / attr(data-height));
-}
+/* JS will handle this case */
+/* .hri-iframe--ratio-auto {} */
 
 .hri-iframe__iframe {
   width: 100%;

--- a/html/themes/custom/common_design_subtheme/components/hri-iframe/hri-iframe.js
+++ b/html/themes/custom/common_design_subtheme/components/hri-iframe/hri-iframe.js
@@ -1,0 +1,15 @@
+/**
+ * HR.info iFrame embeds.
+ */
+(function iife() {
+  var autoIframes = document.querySelectorAll('.hri-iframe--ratio-auto');
+
+  // Did we find iframes with the 'auto' aspect-ratio setting?
+  if (autoIframes) {
+    // For every iframe found, set its CSS aspect-ratio using the attributes
+    // on the container element: data-width, data-height.
+    autoIframes.forEach(function (el) {
+      el.style.aspectRatio = el.dataset.width +' / '+ el.dataset.height;
+    });
+  }
+})();

--- a/html/themes/custom/common_design_subtheme/templates/hr-paragraphs-iframe.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/hr-paragraphs-iframe.html.twig
@@ -13,15 +13,17 @@
     'hri-iframe--' ~ ratio,
   ]
 %}
-<div{{ create_attribute().addClass(classes) }}>
+<div{{ create_attribute()
+  .addClass(classes)
+  .setAttribute('data-width', width)
+  .setAttribute('data-height', height)
+}}>
   <iframe
     class="hri-iframe__iframe"
     sandbox="allow-scripts allow-same-origin"
     allow="autoplay; encrypted-media;"
     width="{{ width }}"
-    data-width="{{ width }}"
     height="{{ height }}"
-    data-height="{{ height }}"
     referrerpolicy="no-referrer"
     frameborder="0"
     target="_blank"


### PR DESCRIPTION
It wasn't possible to have a pure CSS solution, since `attr()` is only guaranteed to work within values for the `content` property, [not other properties](https://developer.mozilla.org/en-US/docs/Web/CSS/attr).

Refs: RWR-275