### PR TITLE
RWR-260 Final tidy, remove commented out CSS rules

### DIFF
--- a/html/themes/custom/common_design_subtheme/components/hri-layout/hri-layout.css
+++ b/html/themes/custom/common_design_subtheme/components/hri-layout/hri-layout.css
@@ -23,14 +23,6 @@
 }
 
 /**
- * Suggest removing rule below.
- */
-/* .hri-layout__sidebar .field--name-field-title {
-  margin-top: 0;
-  font-size: var(--cd-font-size--large);
-} */
-
-/**
  * Two-col
  *
  * Two-col is the layout used by Clusters / Working Groups. You see it on any

--- a/html/themes/custom/common_design_subtheme/components/hri-rss-feed/hri-rss-feed.css
+++ b/html/themes/custom/common_design_subtheme/components/hri-rss-feed/hri-rss-feed.css
@@ -5,11 +5,3 @@
   margin-bottom: 0;
   font-size: var(--cd-font-size--base);
 }
-
-/* .hri-rss-feed .external-feed--list {
-  padding-inline-start: 1.125em;
-}
-
-.hri-rss-feed .external-feed--list li {
-  margin: 0 0 0.75rem 0;
-} */

--- a/html/themes/custom/common_design_subtheme/components/hri-text-block/hri-text-block.css
+++ b/html/themes/custom/common_design_subtheme/components/hri-text-block/hri-text-block.css
@@ -27,21 +27,3 @@
 .field--name-field-text .align-right {
   margin-left: 1rem;
 }
-
-/**
- * Re-implements CD Bullet List so that it applies to WYSIWYG fields.
- *
- * Changes:
- *
- * - margins between list-items are more compact
- * - reading-dir syntax used for padding
- */
-/* .field--name-field-text ul {
-  margin: 0 0 2rem;
-  padding: 0;
-}
-
-.field--name-field-text ul li {
-  margin-inline-start: 1.125em;
-  padding: 0;
-} */

--- a/html/themes/custom/common_design_subtheme/css/styles.css
+++ b/html/themes/custom/common_design_subtheme/css/styles.css
@@ -11,11 +11,6 @@
   border-top: 1px solid var(--brand-grey);
 }
 
-/* .field--name-field-paragraphs-secondary > .field__item + .field__item {
-  margin-top: 2rem;
-  padding-top: 1rem;
-} */
-
 /* Gives Paragraphs with their own Title field vertical rhythm and styles
   the same as .paragraph--type--heading */
 .paragraph--type--reliefweb-document .field--name-field-title + div,


### PR DESCRIPTION
Follow up to https://github.com/UN-OCHA/response-site/pull/420

chore: remove commented out rules for final tidy

Refs: RWR-260