### PR TITLE
[RW-283] Remove query parameters of URL used in reliefweb document paragraphs

### DIFF
--- a/html/modules/custom/hr_paragraphs/hr_paragraphs.module
+++ b/html/modules/custom/hr_paragraphs/hr_paragraphs.module
@@ -5,6 +5,7 @@
  * Themes and preprocessors for the paragraphs page title module.
  */
 
+use Drupal\Component\Utility\UrlHelper;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Breadcrumb\Breadcrumb;
 use Drupal\Core\Entity\EntityInterface;
@@ -1012,6 +1013,9 @@ function hr_paragraphs_preprocess_paragraph__reliefweb_document(&$variables) {
   }
 
   $url = $paragraph->field_reliefweb_url->first()->uri;
+
+  // Remove query parameters.
+  $url = UrlHelper::parse($url)['path'];
 
   /** @var \Drupal\hr_paragraphs\Controller\ReliefwebController */
   $reliefweb_controller = \Drupal::service('hr_paragraphs.reliefweb_controller');


### PR DESCRIPTION
Refs: RW-283

This simply removes the query parameters from the URL used in reliefweb document paragraphs to ensure the URL alias lookup works.

### Tests

**Before checking out this branch**

1. Edit a page (ex: `/fiji`)
2. Add a `reliefweb document` paragraph with a URL to a RW document with a query parameter, ex: `https://reliefweb.int/report/mali/mali-note-dinformations-humanitaires-sur-la-region-de-kidal-rapport-de-situation-1-18-novembre-2022?test`
3. Save the paragraph
4. Check that the document is not displayed in the paragraph preview

**After checking out this branch**

Repeat the above, (4) should show the document in the paragraph preview.