### PR TITLE
fix(locations): always capitalize letter-based navigation

### DIFF
--- a/html/themes/custom/common_design_subtheme/templates/views-view--locations--page-locations.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/views-view--locations--page-locations.html.twig
@@ -92,8 +92,8 @@
           .addClass([
             'rw-river-letter-navigation__link'
           ])
-          .setAttribute('href', '#group-' ~ row['#title']|render|striptags|trim)
-        }}>{{ row['#title']|render|striptags|trim }}</a></li>
+          .setAttribute('href', '#group-' ~ row['#title']|render|striptags|trim|upper)
+        }}>{{ row['#title']|render|striptags|trim|upper }}</a></li>
       {% endfor %}
         <li class="rw-river-letter-navigation__list__item"><a{{ create_attribute()
           .addClass([

--- a/html/themes/custom/common_design_subtheme/templates/views-view-grid.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/views-view-grid.html.twig
@@ -52,9 +52,10 @@
     ]
   %}
 {% endif %}
-<li id="group-{{ title|render|striptags|trim }}" class="rw-river-country-list__group">
+{% set group_letter = title|render|striptags|trim|upper %}
+<li id="group-{{ group_letter }}" class="rw-river-country-list__group">
   {% if title %}
-    <h2 class="rw-river-country-list__group__title">{{ title }}</h2>
+    <h2 class="rw-river-country-list__group__title">{{ group_letter }}</h2>
   {% endif %}
   <div{{ attributes.addClass(classes) }}>
     {% if options.alignment == 'horizontal' %}


### PR DESCRIPTION
Refs: RWR-324

Specifically for oPt since it was creating a lowercase `o` in the heading and letter-navigation.

<img width="496" alt="Screen Shot 2023-02-17 at 11 13 21" src="https://user-images.githubusercontent.com/254753/219616188-935c5137-9600-40ed-bb45-a046a6d1130b.png">
