### PR TITLE
chore: add local config for environment indicator

### DIFF
--- a/config/config_split.config_split.config_dev.yml
+++ b/config/config_split.config_split.config_dev.yml
@@ -13,8 +13,14 @@ module:
   config_filter: 0
   dblog: 0
   devel: 0
+  environment_indicator: 0
   stage_file_proxy: 0
   views_ui: 0
 theme: {  }
-complete_list: {  }
+complete_list:
+  - dblog.settings
+  - devel.settings
+  - devel.toolbar.settings
+  - environment_indicator.indicator
+  - stage_file_proxy.settings
 partial_list: {  }

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -24,7 +24,6 @@ module:
   entity: 0
   entity_reference_revisions: 0
   environment_indicator: 0
-  environment_indicator_ui: 0
   field: 0
   field_group: 0
   field_ui: 0

--- a/config/environment_indicator.switcher.local.yml
+++ b/config/environment_indicator.switcher.local.yml
@@ -1,0 +1,11 @@
+uuid: 42ac34ba-ae60-4b91-953c-5bdd9c09d46a
+langcode: en
+status: true
+dependencies: {  }
+machine: local
+description: null
+name: Local
+weight: ''
+url: 'https://response.test/'
+fg_color: '#ffffff'
+bg_color: '#0d0d0d'

--- a/config_dev/environment_indicator.indicator.yml
+++ b/config_dev/environment_indicator.indicator.yml
@@ -1,0 +1,3 @@
+name: Local
+fg_color: '#ffffff'
+bg_color: '#000000'


### PR DESCRIPTION
Refs: OPS-8939

We already have environment indicator installed and set up for this site - this includes config for local.

Noticed here we have the color for 'dev' that we're using elsewhere for 'feature' - I suggest swapping 'dev' for 'demo' here - but could swap the 'dev' color on the other PRs... Not sure how much this is being used at the moment by us/ content editors.