### PR TITLE
chore: adjust GHActions for running locally

### DIFF
--- a/.github/workflows/composer-update.yml
+++ b/.github/workflows/composer-update.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  update:
     runs-on: ubuntu-latest
     steps:
     - name: Update The Thing

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,11 +9,22 @@ jobs:
     steps:
       - name: Setup PHP with PECL extension
         uses: shivammathur/setup-php@v2
+        if: ${{ !env.ACT }}
         with:
           php-version: 8.1
           tools: composer
         env:
           fail-fast: true
+
+      - name: Setup PHP with PECL extension
+        uses: shivammathur/setup-php@v2
+        if: ${{ env.ACT }}
+        with:
+          php-version: 8.1
+          tools: composer
+        env:
+          fail-fast: true
+          runner: self-hosted
 
       - name: Software versions
         id: versions
@@ -46,6 +57,7 @@ jobs:
 
       - name: Configure AWS Credentials
         id: aws
+        if: ${{ !env.ACT }}
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.ECR_AWS_ACCESS_KEY_ID }}
@@ -54,6 +66,7 @@ jobs:
 
       - name: Login to Public ECR
         id: aws-login
+        if: ${{ !env.ACT }}
         uses: docker/login-action@v2.1.0
         with:
           registry: public.ecr.aws
@@ -76,10 +89,10 @@ jobs:
         uses: cafuego/command-output@main
         with:
           run: |
-            docker-compose -f tests/docker-compose.yml up -d
+            docker compose -f tests/docker-compose.yml up -d
             sleep 10
             docker ps -a
-            docker-compose -f tests/docker-compose.yml exec -w /srv/www -T drupal composer install
+            docker compose -f tests/docker-compose.yml exec -w /srv/www -T drupal composer install
         env:
           fail-fast: true
 
@@ -88,7 +101,7 @@ jobs:
         uses: cafuego/command-output@main
         with:
           run: |
-            docker-compose -f tests/docker-compose.yml exec -u appuser -w /srv/www -T drupal phpcs -p --report=full --standard=phpcs.xml ./html/modules/custom
+            docker compose -f tests/docker-compose.yml exec -u appuser -w /srv/www -T drupal phpcs -p --report=full --standard=phpcs.xml ./html/modules/custom
         env:
           fail-fast: true
 
@@ -97,7 +110,7 @@ jobs:
         uses: cafuego/command-output@main
         with:
           run: |
-            docker-compose -f tests/docker-compose.yml exec -T drupal drush -y si --existing-config
+            docker compose -f tests/docker-compose.yml exec -T drupal drush -y si --existing-config
         env:
           fail-fast: true
 
@@ -106,12 +119,12 @@ jobs:
         uses: cafuego/command-output@main
         with:
           run: |
-            docker-compose -f tests/docker-compose.yml exec -T drupal drush -y en dblog
-            docker-compose -f tests/docker-compose.yml exec -T drupal chmod -R 777 /srv/www/html/sites/default/files /srv/www/html/sites/default/private
-            docker-compose -f tests/docker-compose.yml exec -T drupal mkdir -p /srv/www/html/build/logs
-            docker-compose -f tests/docker-compose.yml exec -T drupal chmod -R 777 /srv/www/html/build/logs
-            docker-compose -f tests/docker-compose.yml exec -T -w /srv/www -e XDEBUG_MODE=coverage -e BROWSERTEST_OUTPUT_DIRECTORY=/srv/www/html/sites/default/files/browser_output -e DTT_BASE_URL=http://127.0.0.1 drupal ./vendor/bin/phpunit --coverage-clover /srv/www/html/build/logs/clover.xml --debug
-            docker cp "$(docker-compose -f tests/docker-compose.yml ps -q drupal)":/srv/www/html/build/logs/clover.xml .
+            docker compose -f tests/docker-compose.yml exec -T drupal drush -y en dblog
+            docker compose -f tests/docker-compose.yml exec -T drupal chmod -R 777 /srv/www/html/sites/default/files /srv/www/html/sites/default/private
+            docker compose -f tests/docker-compose.yml exec -T drupal mkdir -p /srv/www/html/build/logs
+            docker compose -f tests/docker-compose.yml exec -T drupal chmod -R 777 /srv/www/html/build/logs
+            docker compose -f tests/docker-compose.yml exec -T -w /srv/www -e XDEBUG_MODE=coverage -e BROWSERTEST_OUTPUT_DIRECTORY=/srv/www/html/sites/default/files/browser_output -e DTT_BASE_URL=http://127.0.0.1 drupal ./vendor/bin/phpunit --coverage-clover /srv/www/html/build/logs/clover.xml --debug
+            docker cp "$(docker compose -f tests/docker-compose.yml ps -q drupal)":/srv/www/html/build/logs/clover.xml .
         env:
           fail-fast: true
 
@@ -127,6 +140,7 @@ jobs:
 
       - name: Find Comment
         uses: peter-evans/find-comment@v2
+        if: ${{ !env.ACT }}
         id: fc
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -136,6 +150,7 @@ jobs:
 
       - name: Create or update comment
         uses: peter-evans/create-or-update-comment@v2
+        if: ${{ !env.ACT }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-id: ${{ steps.fc.outputs.comment-id }}
@@ -160,7 +175,7 @@ jobs:
 
       - name: Slack Success Notification
         id: slack_success
-        if: success()
+        if: ${{ !env.ACT }} && success()
         uses: slackapi/slack-github-action@v1.23.0
         with:
           channel-id: '${{ secrets.SLACK_CHANNEL }}'
@@ -187,7 +202,7 @@ jobs:
 
       - name: Slack Failure Notification
         id: slack_failure
-        if: failure()
+        if: ${{ !env.ACT }} && failure()
         uses: slackapi/slack-github-action@v1.23.0
         with:
           channel-id: '${{ secrets.SLACK_CHANNEL }}'
@@ -211,3 +226,13 @@ jobs:
             }
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+      - name: Clean up
+        id: docker-clean-up
+        if: ${{ env.ACT }}
+        uses: cafuego/command-output@main
+        with:
+          run: |
+            docker compose -f tests/docker-compose.yml down
+        env:
+          fail-fast: true

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -18,10 +18,10 @@
     <!-- Do not limit the amount of memory tests take to run. -->
     <ini name="memory_limit" value="-1"/>
     <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
-    <env name="DTT_BASE_URL" value="http://hrinfo-site.docksal.site/"/>
+    <env name="DTT_BASE_URL" value="http://response.test/"/>
     <env name="DTT_API_URL" value="http://localhost:9222"/>
     <!-- Example SIMPLETEST_BASE_URL value: http://localhost -->
-    <env name="SIMPLETEST_BASE_URL" value="http://hrinfo-site.docksal.site/"/>
+    <env name="SIMPLETEST_BASE_URL" value="http://response.test/"/>
     <!-- Example SIMPLETEST_DB value: mysql://username:password@localhost/databasename#table_prefix -->
     <env name="SIMPLETEST_DB" value="mysql://user:user@db/test"/>
     <!-- Example BROWSERTEST_OUTPUT_DIRECTORY value: /path/to/webroot/sites/simpletest/browser_output -->


### PR DESCRIPTION
Refs: OPS-9006

A couple of things to note:
`docker-compose` is v1, which will stop being supported at the end of June, from then on it's `docker compose` without the hyphen, which is v2.
https://docs.docker.com/compose/compose-v2/#differences-between-compose-v1-and-compose-v2

`if: ${{ !env.ACT }}` is to skip the step if it's being run with https://github.com/nektos/act - I've got this going locally and find it useful - it certainly saved a lot of time and noise in my GHA interactions so far. If it's only me using it, then I can make adjustments locally, but I'd be interested to see if anyone else finds it useful.