### PR TITLE
chore: Use the normal PHP image for the build.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Build the code.
-FROM public.ecr.aws/unocha/unified-builder:8.1-stable as builder
+FROM public.ecr.aws/unocha/php-k8s:8.1-stable as builder
 
 ARG  BRANCH_ENVIRONMENT
 


### PR DESCRIPTION
The builder is no longer maintained, since the current common_design theme no longer requires sass to build assets.

Refs: OPS-9161