### PR TITLE
fix: include patch to recognize previous revisions

### DIFF
--- a/PATCHES/linkchecker-previous-revisions-3366753.patch
+++ b/PATCHES/linkchecker-previous-revisions-3366753.patch
@@ -1,8 +1,16 @@
 diff --git a/src/Plugin/views/field/LinkcheckerLinkPageEntityLabel.php b/src/Plugin/views/field/LinkcheckerLinkPageEntityLabel.php
-index d2fa1ed5dfa11d9588c360b98c0d9649344dad6f..aad98947ddb6cc8804c8c5f3645be47608251803 100644
+index d2fa1ed5dfa11d9588c360b98c0d9649344dad6f..e844753b020743cc0cf85675a4c82a2c6f545507 100644
 --- a/src/Plugin/views/field/LinkcheckerLinkPageEntityLabel.php
 +++ b/src/Plugin/views/field/LinkcheckerLinkPageEntityLabel.php
-@@ -71,8 +71,20 @@ class LinkcheckerLinkPageEntityLabel extends FieldPluginBase {
+@@ -6,6 +6,7 @@ use Drupal\Core\Entity\EntityInterface;
+ use Drupal\Core\Entity\EntityMalformedException;
+ use Drupal\Core\Entity\Exception\UndefinedLinkTemplateException;
+ use Drupal\Core\Form\FormStateInterface;
++use Drupal\entity_reference_revisions\EntityReferenceRevisionsFieldItemList;
+ use Drupal\linkchecker\LinkCheckerLinkInterface;
+ use Drupal\views\Plugin\views\field\FieldPluginBase;
+ use Drupal\views\ResultRow;
+@@ -71,8 +72,30 @@ class LinkcheckerLinkPageEntityLabel extends FieldPluginBase {
        return '';
      }
  
@@ -10,15 +18,25 @@ index d2fa1ed5dfa11d9588c360b98c0d9649344dad6f..aad98947ddb6cc8804c8c5f3645be476
      if ($linked_entity->getEntityTypeId() === 'paragraph' && $linked_entity->getParentEntity() !== NULL) {
        $linked_entity = $linked_entity->getParentEntity();
 +      $previous_revision = TRUE;
-+      foreach ($linked_entity->field_paragraphs->getValue() as $target_ids) {
-+        if ($revision_id == $target_ids['target_revision_id']) {
-+          $previous_revision = FALSE;
-+          continue;
-+        };
++      $field_names = [];
++      foreach ($linked_entity->getFields() as $field) {
++        if ($field instanceof EntityReferenceRevisionsFieldItemList) {
++          $field_names[] = $field->getName();
++        }
 +      }
++
++      foreach ($field_names as $field_name) {
++        foreach ($linked_entity->$field_name->getValue() as $target_ids) {
++          if ($revision_id == $target_ids['target_revision_id']) {
++            $previous_revision = FALSE;
++            continue;
++          };
++        }
++      }
++
 +      if ($previous_revision) {
 +        $this->options['alter']['make_link'] = FALSE;
-+        return $this->t('The link is from a previous revision of a paragraph.');
++        return $this->t('The linked content originates from a prior revision of a paragraph.');
 +      }
      }
  

--- a/PATCHES/linkchecker-previous-revisions-3366753.patch
+++ b/PATCHES/linkchecker-previous-revisions-3366753.patch
@@ -1,0 +1,25 @@
+diff --git a/src/Plugin/views/field/LinkcheckerLinkPageEntityLabel.php b/src/Plugin/views/field/LinkcheckerLinkPageEntityLabel.php
+index d2fa1ed5dfa11d9588c360b98c0d9649344dad6f..aad98947ddb6cc8804c8c5f3645be47608251803 100644
+--- a/src/Plugin/views/field/LinkcheckerLinkPageEntityLabel.php
++++ b/src/Plugin/views/field/LinkcheckerLinkPageEntityLabel.php
+@@ -71,8 +71,20 @@ class LinkcheckerLinkPageEntityLabel extends FieldPluginBase {
+       return '';
+     }
+ 
++    $revision_id = $linked_entity->getRevisionId();
+     if ($linked_entity->getEntityTypeId() === 'paragraph' && $linked_entity->getParentEntity() !== NULL) {
+       $linked_entity = $linked_entity->getParentEntity();
++      $previous_revision = TRUE;
++      foreach ($linked_entity->field_paragraphs->getValue() as $target_ids) {
++        if ($revision_id == $target_ids['target_revision_id']) {
++          $previous_revision = FALSE;
++          continue;
++        };
++      }
++      if ($previous_revision) {
++        $this->options['alter']['make_link'] = FALSE;
++        return $this->t('The link is from a previous revision of a paragraph.');
++      }
+     }
+ 
+     if (!empty($this->options['link_to_entity'])) {

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -17,8 +17,7 @@
         "drupal/linkchecker": {
           "Provide a list of unconfigured but eligible fields - https://www.drupal.org/project/linkchecker/issues/3244743": "PATCHES/linkchecker-unconfirmed-but-eligible-field-list-3244743.patch",
           "Do not break admin denied": "./PATCHES/linkchecker_use_uid.patch",
-          "Avoid null links": "./PATCHES/linkchecker_null_link.patch",
-          "Recognize previous revisions https://www.drupal.org/project/linkchecker/issues/3366753#comment-15106979": "./PATCHES/linkchecker-previous-revisions-3366753.patch"
+          "Avoid null links": "./PATCHES/linkchecker_null_link.patch"
         },
         "drupal/maintenance200": {
           "Drupal 10 compatibility": "PATCHES/maintenance200-drupal-10-compatibility.patch"

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -17,7 +17,8 @@
         "drupal/linkchecker": {
           "Provide a list of unconfigured but eligible fields - https://www.drupal.org/project/linkchecker/issues/3244743": "PATCHES/linkchecker-unconfirmed-but-eligible-field-list-3244743.patch",
           "Do not break admin denied": "./PATCHES/linkchecker_use_uid.patch",
-          "Avoid null links": "./PATCHES/linkchecker_null_link.patch"
+          "Avoid null links": "./PATCHES/linkchecker_null_link.patch",
+          "Recognize previous revisions https://www.drupal.org/project/linkchecker/issues/3366753": "./PATCHES/linkchecker-previous-revisions-3366753.patch"
         },
         "drupal/maintenance200": {
           "Drupal 10 compatibility": "PATCHES/maintenance200-drupal-10-compatibility.patch"

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -17,7 +17,8 @@
         "drupal/linkchecker": {
           "Provide a list of unconfigured but eligible fields - https://www.drupal.org/project/linkchecker/issues/3244743": "PATCHES/linkchecker-unconfirmed-but-eligible-field-list-3244743.patch",
           "Do not break admin denied": "./PATCHES/linkchecker_use_uid.patch",
-          "Avoid null links": "./PATCHES/linkchecker_null_link.patch"
+          "Avoid null links": "./PATCHES/linkchecker_null_link.patch",
+          "Recognize previous revisions https://www.drupal.org/project/linkchecker/issues/3366753#comment-15106979": "./PATCHES/linkchecker-previous-revisions-3366753.patch"
         },
         "drupal/maintenance200": {
           "Drupal 10 compatibility": "PATCHES/maintenance200-drupal-10-compatibility.patch"

--- a/html/modules/custom/hr_paragraphs/hr_paragraphs.module
+++ b/html/modules/custom/hr_paragraphs/hr_paragraphs.module
@@ -21,6 +21,9 @@ use Drupal\group\Entity\GroupRelationship;
 use Drupal\node\Entity\Node;
 use Drupal\path_alias\Entity\PathAlias;
 use Drupal\subgroup\MalformedLeafException;
+use Drupal\views\Plugin\views\query\QueryPluginBase;
+use Drupal\views\ViewExecutable;
+use Drupal\views\Views;
 
 /**
  * Implements hook_theme().
@@ -2427,4 +2430,52 @@ function hr_paragraphs_editor_js_settings_alter(array &$settings) {
     $format_tags = str_replace('h1;', '', $settings['editor']['formats']['basic_html']['editorSettings']['format_tags']);
     $settings['editor']['formats']['basic_html']['editorSettings']['format_tags'] = $format_tags;
   }
+}
+
+/**
+ * Implements hook_views_query_alter().
+ */
+function hr_paragraphs_views_query_alter(ViewExecutable $view, QueryPluginBase $query) {
+  if ($view->id() !== 'db_links') {
+    return;
+  }
+
+  /** @var \Drupal\views\Plugin\views\query\Sql $query */
+
+  // Link to parents using paragraph fields.
+  $configuration = [
+    'type' => 'LEFT',
+    'table' => 'group__field_paragraphs',
+    'field' => 'field_paragraphs_target_id',
+    'left_table' => 'linkchecker_link',
+    'left_field' => 'entity_id__target_id',
+    'operator' => '=',
+  ];
+  $join = Views::pluginManager('join')->createInstance('standard', $configuration);
+  $query->addRelationship('gfp', $join, 'linkchecker_link');
+
+  $configuration = [
+    'type' => 'LEFT',
+    'table' => 'group__field_sidebar_menu',
+    'field' => 'field_sidebar_menu_target_id',
+    'left_table' => 'linkchecker_link',
+    'left_field' => 'entity_id__target_id',
+    'operator' => '=',
+  ];
+  $join = Views::pluginManager('join')->createInstance('standard', $configuration);
+  $query->addRelationship('gfsm', $join, 'linkchecker_link');
+
+  $configuration = [
+    'type' => 'LEFT',
+    'table' => 'node__field_paragraphs',
+    'field' => 'field_paragraphs_target_id',
+    'left_table' => 'linkchecker_link',
+    'left_field' => 'entity_id__target_id',
+    'operator' => '=',
+  ];
+  $join = Views::pluginManager('join')->createInstance('standard', $configuration);
+  $query->addRelationship('nfp', $join, 'linkchecker_link');
+
+  // Check that at least one isn't NULL.
+  $query->addWhereExpression('activeonly', 'gfp.field_paragraphs_target_id is not null or nfp.field_paragraphs_target_id is not null or gfsm.field_sidebar_menu_target_id is not null');
 }

--- a/html/modules/custom/hr_paragraphs/hr_paragraphs.module
+++ b/html/modules/custom/hr_paragraphs/hr_paragraphs.module
@@ -21,9 +21,6 @@ use Drupal\group\Entity\GroupRelationship;
 use Drupal\node\Entity\Node;
 use Drupal\path_alias\Entity\PathAlias;
 use Drupal\subgroup\MalformedLeafException;
-use Drupal\views\Plugin\views\query\QueryPluginBase;
-use Drupal\views\ViewExecutable;
-use Drupal\views\Views;
 
 /**
  * Implements hook_theme().
@@ -2433,49 +2430,15 @@ function hr_paragraphs_editor_js_settings_alter(array &$settings) {
 }
 
 /**
- * Implements hook_views_query_alter().
+ * Implements hook_views_data_alter().
  */
-function hr_paragraphs_views_query_alter(ViewExecutable $view, QueryPluginBase $query) {
-  if ($view->id() !== 'db_links') {
-    return;
-  }
-
-  /** @var \Drupal\views\Plugin\views\query\Sql $query */
-
-  // Link to parents using paragraph fields.
-  $configuration = [
-    'type' => 'LEFT',
-    'table' => 'group__field_paragraphs',
-    'field' => 'field_paragraphs_target_id',
-    'left_table' => 'linkchecker_link',
-    'left_field' => 'entity_id__target_id',
-    'operator' => '=',
+function hr_paragraphs_views_data_alter(array &$data) {
+  $data['linkchecker_link']['active_revisions'] = [
+    'title' => t('Filter out old revisions'),
+    'help' => t('Filter out old revisions.'),
+    'filter' => [
+      'title' => t('Filter out old revisions'),
+      'id' => 'linkchecker_link_active_revisions',
+    ],
   ];
-  $join = Views::pluginManager('join')->createInstance('standard', $configuration);
-  $query->addRelationship('gfp', $join, 'linkchecker_link');
-
-  $configuration = [
-    'type' => 'LEFT',
-    'table' => 'group__field_sidebar_menu',
-    'field' => 'field_sidebar_menu_target_id',
-    'left_table' => 'linkchecker_link',
-    'left_field' => 'entity_id__target_id',
-    'operator' => '=',
-  ];
-  $join = Views::pluginManager('join')->createInstance('standard', $configuration);
-  $query->addRelationship('gfsm', $join, 'linkchecker_link');
-
-  $configuration = [
-    'type' => 'LEFT',
-    'table' => 'node__field_paragraphs',
-    'field' => 'field_paragraphs_target_id',
-    'left_table' => 'linkchecker_link',
-    'left_field' => 'entity_id__target_id',
-    'operator' => '=',
-  ];
-  $join = Views::pluginManager('join')->createInstance('standard', $configuration);
-  $query->addRelationship('nfp', $join, 'linkchecker_link');
-
-  // Check that at least one isn't NULL.
-  $query->addWhereExpression('activeonly', 'gfp.field_paragraphs_target_id is not null or nfp.field_paragraphs_target_id is not null or gfsm.field_sidebar_menu_target_id is not null');
 }

--- a/html/modules/custom/hr_paragraphs/src/Plugin/views/filter/LinkcheckerLinkActiveRevisions.php
+++ b/html/modules/custom/hr_paragraphs/src/Plugin/views/filter/LinkcheckerLinkActiveRevisions.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Drupal\hr_paragraphs\Plugin\views\filter;
+
+use Drupal\views\Plugin\views\filter\FilterPluginBase;
+use Drupal\views\Views;
+
+/**
+ * Field handler to filter active revisions.
+ *
+ * @ingroup views_field_handlers
+ *
+ * @ViewsFilter("linkchecker_link_active_revisions")
+ */
+class LinkcheckerLinkActiveRevisions extends FilterPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function adminSummary() {
+    return 'Active only';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function canExpose() {
+    return FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
+    /** @var \Drupal\views\Plugin\views\query\Sql $query */
+    $query = $this->query;
+    $entity_type_manager = \Drupal::entityTypeManager();
+
+    $fields = $entity_type_manager->getStorage('field_storage_config')->loadByProperties([
+      'type' => 'entity_reference_revisions',
+      'settings' => [
+        'target_type' => 'paragraph',
+      ],
+    ]);
+
+    // Force numeric ids.
+    $fields = array_values($fields);
+    $wherefields = [];
+
+    /** @var \Drupal\field\Entity\FieldStorageConfig $field */
+    foreach ($fields as $id => $field) {
+      // Skip nested paragraphs.
+      if ($field->getTargetEntityTypeId() == 'paragraph') {
+        continue;
+      }
+
+      $configuration = [
+        'type' => 'LEFT',
+        'table' => $field->getTargetEntityTypeId() . '__' . $field->getName(),
+        'field' => $field->getName() . '_target_id',
+        'left_table' => 'linkchecker_link',
+        'left_field' => 'entity_id__target_id',
+        'operator' => '=',
+      ];
+
+      $join = Views::pluginManager('join')->createInstance('standard', $configuration);
+      $query->addRelationship('lclf' . $id, $join, 'linkchecker_link');
+      $wherefields[] = 'lclf' . $id . '.' . $field->getName() . '_target_id IS NOT NULL';
+    }
+
+    // Check that at least one isn't NULL.
+    if (!empty($wherefields)) {
+      $query->addWhereExpression('activeonly', implode(' OR ', $wherefields));
+    }
+  }
+
+}


### PR DESCRIPTION
Refs: RWR-355

This is only a part of the solution for the Dead links view, but I think it gets us a little closer.

This patch alters the field where the link is found if it's in a previous version of a paragraph.

![image](https://github.com/UN-OCHA/response-site/assets/67453/22c71967-0938-4cee-8441-988c2388420c)

("OCHA_Mali" is a good url to test with, as there is currently one version in a current paragraph and one in a previous revision.) 

@attiks if I understand right, the next step is to add a views filter plugin for the Entity Label field. Is that right?