### PR TITLE
chore: include views config for db_links filter

### DIFF
--- a/config/views.view.db_links.yml
+++ b/config/views.view.db_links.yml
@@ -5,6 +5,7 @@ dependencies:
   module:
     - csv_serialization
     - dynamic_entity_reference
+    - hr_paragraphs
     - linkchecker
     - rest
     - serialization
@@ -593,6 +594,45 @@ display:
             remember: false
             multiple: false
             placeholder: null
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        active_revisions:
+          id: active_revisions
+          table: linkchecker_link
+          field: active_revisions
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: linkcheckerlink
+          plugin_id: linkchecker_link_active_revisions
+          operator: '='
+          value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
           is_grouped: false
           group_info:
             label: ''
@@ -2167,161 +2207,6 @@ display:
         type: perm
         options:
           perm: 'administer nodes'
-      filters:
-        status:
-          id: status
-          table: linkchecker_link
-          field: status
-          entity_type: linkcheckerlink
-          entity_field: status
-          plugin_id: boolean
-          value: '1'
-          group: 1
-          expose:
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-        code_1:
-          id: code_1
-          table: linkchecker_link
-          field: code
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: linkcheckerlink
-          entity_field: code
-          plugin_id: numeric
-          operator: between
-          value:
-            min: ''
-            max: ''
-            value: ''
-          group: 1
-          exposed: true
-          expose:
-            operator_id: code_1_op
-            label: 'Status code'
-            description: ''
-            use_operator: false
-            operator: code_1_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: code_1
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-              global_editor: '0'
-            min_placeholder: ''
-            max_placeholder: ''
-            placeholder: ''
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-        url:
-          id: url
-          table: linkchecker_link
-          field: url
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: linkcheckerlink
-          entity_field: url
-          plugin_id: string
-          operator: contains
-          value: ''
-          group: 1
-          exposed: true
-          expose:
-            operator_id: url_op
-            label: URL
-            description: ''
-            use_operator: false
-            operator: url_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: url
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-              global_editor: '0'
-            placeholder: ''
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-        link_type:
-          id: link_type
-          table: linkchecker_link
-          field: link_type
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: linkcheckerlink
-          entity_field: link_type
-          plugin_id: string
-          operator: '='
-          value: ''
-          group: 1
-          exposed: true
-          expose:
-            operator_id: link_type_op
-            label: 'Type of link'
-            description: 'Possible values: application, assessment, cluster, document, documents, file, home, infographic, infographics, node, operation, '
-            use_operator: true
-            operator: link_type_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: link_type
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-              global_editor: '0'
-            placeholder: ''
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-      filter_groups:
-        operator: AND
-        groups:
-          1: AND
       defaults:
         use_ajax: false
         pager: false
@@ -2329,8 +2214,8 @@ display:
         use_more_always: false
         use_more_text: false
         fields: false
-        filters: false
-        filter_groups: false
+        filters: true
+        filter_groups: true
       use_ajax: false
       use_more: false
       use_more_always: true

--- a/config/views.view.db_links.yml
+++ b/config/views.view.db_links.yml
@@ -606,45 +606,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-        active_revisions:
-          id: active_revisions
-          table: linkchecker_link
-          field: active_revisions
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: linkcheckerlink
-          plugin_id: linkchecker_link_active_revisions
-          operator: '='
-          value: ''
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
       style:
         type: table
         options:
@@ -2207,6 +2168,200 @@ display:
         type: perm
         options:
           perm: 'administer nodes'
+      filters:
+        status:
+          id: status
+          table: linkchecker_link
+          field: status
+          entity_type: linkcheckerlink
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        code_1:
+          id: code_1
+          table: linkchecker_link
+          field: code
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: linkcheckerlink
+          entity_field: code
+          plugin_id: numeric
+          operator: between
+          value:
+            min: ''
+            max: ''
+            value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: code_1_op
+            label: 'Status code'
+            description: ''
+            use_operator: false
+            operator: code_1_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: code_1
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              global_editor: '0'
+            min_placeholder: ''
+            max_placeholder: ''
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        url:
+          id: url
+          table: linkchecker_link
+          field: url
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: linkcheckerlink
+          entity_field: url
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: url_op
+            label: URL
+            description: ''
+            use_operator: false
+            operator: url_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: url
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              global_editor: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        link_type:
+          id: link_type
+          table: linkchecker_link
+          field: link_type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: linkcheckerlink
+          entity_field: link_type
+          plugin_id: string
+          operator: '='
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: link_type_op
+            label: 'Type of link'
+            description: 'Possible values: application, assessment, cluster, document, documents, file, home, infographic, infographics, node, operation, '
+            use_operator: true
+            operator: link_type_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: link_type
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              global_editor: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        active_revisions:
+          id: active_revisions
+          table: linkchecker_link
+          field: active_revisions
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: linkcheckerlink
+          plugin_id: linkchecker_link_active_revisions
+          operator: '='
+          value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
       defaults:
         use_ajax: false
         pager: false
@@ -2214,8 +2369,8 @@ display:
         use_more_always: false
         use_more_text: false
         fields: false
-        filters: true
-        filter_groups: true
+        filters: false
+        filter_groups: false
       use_ajax: false
       use_more: false
       use_more_always: true


### PR DESCRIPTION
RWR-355 - follow up to previous deploy - include the configuration so the filter is added to the view. (Has been altered via config on production, this to keep the config up-to-date.)