### PR TITLE
[RWR-373] Make text optional on cards

### DIFF
--- a/config/field.field.paragraph.featured_highlight.field_text.yml
+++ b/config/field.field.paragraph.featured_highlight.field_text.yml
@@ -18,7 +18,7 @@ entity_type: paragraph
 bundle: featured_highlight
 label: Text
 description: 'When displayed, this Text field will end at the last full sentence before the 280 character limit.'
-required: true
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/config/social_auth_hid.settings.yml
+++ b/config/social_auth_hid.settings.yml
@@ -8,5 +8,5 @@ disable_default: true
 disable_password_fields: true
 disable_email_field: true
 disable_user_field: true
+disable_user_create: false
 maintenance_access: false
-disable_user_create: 0


### PR DESCRIPTION
# RWR-373

Makes the text optional on cards. The layout will survive:

<img width="742" alt="Screenshot 2023-09-20 at 15 46 46" src="https://github.com/UN-OCHA/response-site/assets/254753/cbc1d896-4cbf-445e-9eeb-511400f5cbe0">
