### PR TITLE
[RWR-368] Proper processing of date filters for the RW rivers

### DIFF
--- a/html/modules/custom/hr_paragraphs/hr_paragraphs.module
+++ b/html/modules/custom/hr_paragraphs/hr_paragraphs.module
@@ -1318,6 +1318,16 @@ function hr_paragraphs_validate_date_filter_values($code, array $values) {
     }
   }
 
+  // Format the dates to ISO 8601.
+  if (!empty($dates['from'])) {
+    $dates['from'] = $dates['from']->format('c');
+  }
+  // The `to` date is inclusive, so we add 1 day minus 1 second to the
+  // `to` date so that we cover the entire day.
+  if (!empty($dates['to'])) {
+    $dates['to'] = $dates['to']->modify('+1 day -1 second')->format('c');
+  }
+
   return $dates;
 }
 

--- a/html/modules/custom/hr_paragraphs/src/Controller/ReliefwebController.php
+++ b/html/modules/custom/hr_paragraphs/src/Controller/ReliefwebController.php
@@ -608,6 +608,7 @@ class ReliefwebController extends ControllerBase {
           }
           else {
             $conditions[$key] = $condition;
+            $conditions[$key]['value'] = $condition['processed'] ?? $condition['value'];
           }
         }
       }


### PR DESCRIPTION
Refs: RWR-368

This fixes the query to the RW API when there RW river URL contains a date filter.

Examples:

1. https://reliefweb.int/updates?view=reports&advanced-search=%28DA20230801-%29 -- (`from` date only)
2. https://reliefweb.int/updates?view=reports&advanced-search=%28DA20230924%29 -- (`from` and `to` dates, same date = on the day)
3. https://reliefweb.int/updates?view=reports&advanced-search=%28DA20230801-%29 -- (`from` and `to` dates)

## Tests.

1. Before checking out this branch, add 3 RW feeds paragraph types to a page with the URLs above
4. Save and confirm you get the "ReliefWeb data is currently not available." message for the 3 paragraphs.
5. Check out the branch, clear the cache
6. Refresh the page from (2) and confirm that the RW reports appear in each paragraph and match what is displayed on RW with the URLs above.