### PR TITLE
fix: The dependencies for the default container must always be an array, never `null`.

### DIFF
--- a/config/google_tag.container.default.yml
+++ b/config/google_tag.container.default.yml
@@ -1,7 +1,7 @@
 uuid: 5baec9c6-24e6-454d-a6fe-53699fb0f183
 langcode: en
 status: true
-dependencies: null
+dependencies: {  }
 id: default
 label: default
 weight: 0


### PR DESCRIPTION
Because when it's `null` trying to save the settings form results in a WSOD and nobody wants that.

Refs: RWR-382