### PR TITLE
chore: remove unused user_expire module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,6 @@
         "drupal/subgroup": "^2.0.0-beta1",
         "drupal/theme_switcher": "^1.2",
         "drupal/twig_tweak": "^3.1",
-        "drupal/user_expire": "^1.0",
         "drupal/username_enumeration_prevention": "^1.3",
         "drupal/views_data_export": "^1.2",
         "drupal/views_field_compare": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a6726df303b5a17bc4323b8af4db78ff",
+    "content-hash": "9b9981909f846cdf5de7e0f4e3d8b9c1",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4993,61 +4993,6 @@
             "support": {
                 "source": "https://git.drupalcode.org/project/twig_tweak",
                 "issues": "https://www.drupal.org/project/issues/twig_tweak"
-            }
-        },
-        {
-            "name": "drupal/user_expire",
-            "version": "1.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/user_expire.git",
-                "reference": "8.x-1.1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/user_expire-8.x-1.1.zip",
-                "reference": "8.x-1.1",
-                "shasum": "060bea37c7b2bd5edcc2a607af6ff62284784f77"
-            },
-            "require": {
-                "drupal/core": "^9 || ^10"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "drupal": {
-                    "version": "8.x-1.1",
-                    "datestamp": "1664991736",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0+"
-            ],
-            "authors": [
-                {
-                    "name": "Erik Webb (erikwebb)",
-                    "homepage": "https://www.drupal.org/u/erikwebb",
-                    "role": "Maintainer"
-                },
-                {
-                    "name": "Greg Knaddison (greggles)",
-                    "homepage": "https://www.drupal.org/u/greggles",
-                    "role": "Co-maintainer"
-                },
-                {
-                    "name": "shelane",
-                    "homepage": "https://www.drupal.org/user/2674989"
-                }
-            ],
-            "description": "Allows an administrator to define a date on which to expire a user account.",
-            "homepage": "https://www.drupal.org/project/user_expire",
-            "support": {
-                "source": "https://git.drupal.org/project/user_expire.git",
-                "issues": "https://www.drupal.org/project/issues/user_expire"
             }
         },
         {
@@ -16159,5 +16104,5 @@
         "php": "8.*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
Refs: RWR-354

The ticket says "Module to remain disabled until further notice. Content Squad will review users manually on a regular basis for now." but no sign of it being used again soon and if so we can add it again. This PR removes the module completely to keep things more tidy.