### PR TITLE
chore: remove outdated allow-plugin directive

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -135,7 +135,6 @@
             "composer/installers": true,
             "cweagans/composer-patches": true,
             "dealerdirect/phpcodesniffer-composer-installer": true,
-            "drupal-composer/preserve-paths": true,
             "drupal/core-composer-scaffold": true,
             "drupal/core-project-message": true,
             "drupal/console-extend-plugin": true,


### PR DESCRIPTION
Refs: OPS-9635

Composer sometimes prompts to allow or deny the preserve-paths plugin, even though it was removed some time ago. Not sure why it happens, but hoping it won't happen again.