### PR TITLE
chore: uninstall ckeditor module

### DIFF
--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -6,7 +6,6 @@ module:
   big_pipe: 0
   block: 0
   breakpoint: 0
-  ckeditor: 0
   ckeditor5: 0
   components: 0
   config: 0


### PR DESCRIPTION
Refs: OPS-9268

We're using core's CKEditor5 - we don't need the ckeditor module any longer. This as the preliminary step to removing it completely.

Follows https://github.com/UN-OCHA/response-site/pull/615 which was merged two months ago.