### PR TITLE
chore: include composer self-update step

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,6 +12,7 @@ WORKDIR /srv/www
 
 # Clean up previous composer installation and run new one.
 RUN rm -rf ./vendor && \
+    composer self-update && \
     composer install --no-interaction --no-dev
 
 # Copy settings to default site location.


### PR DESCRIPTION
Refs: OPS-9635

Composer is already updated in composer.lock so tomorrow's deployment should fix the issue for the moment anyway:
![image](https://github.com/UN-OCHA/response-site/assets/67453/b5564d76-20f4-49e5-957d-617e09966361)
