### PR TITLE
fix: don't pre-render URLs on cards

### DIFF
--- a/html/themes/custom/common_design_subtheme/templates/paragraph--card-list--featured-highlight.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraph--card-list--featured-highlight.html.twig
@@ -32,7 +32,7 @@
         {{ content.field_image }}
         <h3 class="hri-card__title">{{ content.field_title.0 }}</h3>
         <p class="hri-card__summary">{{ content.field_text|render|striptags|trim|replace({'&nbsp;': ''}) }}</p>
-        <a href="{{ content.field_destination|render|striptags|trim }}" class="hri-card__link" title="{{ 'View more'|t }}">{{ 'View more'|t }}</a>
+        <a href="{{ paragraph.field_destination.0.url }}" class="hri-card__link" title="{{ 'View more'|t }}">{{ 'View more'|t }}</a>
       </div>
     {% endblock %}
   </article>


### PR DESCRIPTION
Using `content.field_destination|render` causes double-encoding. Fix uses the raw URL as output instead. I double-checked other uses of `field_destination` in the codebase and all the others already use `paragraph.field_destination.0.url` — this was the last one that needed fixing.

Refs: RWR-415