### PR TITLE
feat: Restrict access to edit group title

### DIFF
--- a/config/user.role.global_editor.yml
+++ b/config/user.role.global_editor.yml
@@ -125,6 +125,7 @@ permissions:
   - 'revert all revisions'
   - 'revert landing_page revisions'
   - 'revert page revisions'
+  - 'rwr edit group title'
   - 'rwr edit meta tags'
   - 'rwr unpublish group'
   - 'switch shortcut sets'

--- a/html/modules/custom/hr_paragraphs/hr_paragraphs.module
+++ b/html/modules/custom/hr_paragraphs/hr_paragraphs.module
@@ -1928,18 +1928,23 @@ function hr_paragraphs_form_alter(&$form, $form_state, $form_id) {
       unset($form['field_enabled_tabs']['widget']['#options']['pages']);
     }
 
+    $user = \Drupal::currentUser();
+
     // Hide language option for managers.
     if (isset($form['langcode'])) {
-      $user = \Drupal::currentUser();
       if (!$user->hasPermission('create operation group')) {
         $form['langcode']['#access'] = FALSE;
       }
     }
 
     // Restrict access to status.
-    $user = \Drupal::currentUser();
     if (!$user->hasPermission('rwr unpublish group')) {
       $form['status']['#access'] = FALSE;
+    }
+
+    // Restrict access to edit title.
+    if (strpos($form_id, '_edit_form') !== FALSE && !$user->hasPermission('rwr edit group title')) {
+      $form['label']['#disabled'] = TRUE;
     }
   }
 

--- a/html/modules/custom/hr_paragraphs/hr_paragraphs.permissions.yml
+++ b/html/modules/custom/hr_paragraphs/hr_paragraphs.permissions.yml
@@ -4,3 +4,6 @@ rwr edit meta tags:
 rwr unpublish group:
   title: 'Unpublish operations and clusters'
   restrict access: true
+rwr edit group title:
+  title: 'Edit title of an operations or a clusters'
+  restrict access: true


### PR DESCRIPTION
Changes

- Operation manager can set title on new cluster
- Operation manager cannot edit title on operation or cluster
- Global editor can still edit title

Refs: #RWR-428