### PR TITLE
chore: update linkchecker dependency to remove a patch

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4373,7 +4373,7 @@
                 "shasum": "fc8ea60619b6b4682bade340e13fb4565d3a7e0c"
             },
             "require": {
-                "drupal/core": "^8 || ^9 || ^10 || ^11"
+                "drupal/core": "^10"
             },
             "type": "drupal-module",
             "extra": {
@@ -5652,7 +5652,7 @@
                 "shasum": "9ea9eee91cf75f21fcc939704baa6a7ec10d7748"
             },
             "require": {
-                "drupal/core": "^8 || ^9 || ^10 || ^11"
+                "drupal/core": "^10"
             },
             "type": "drupal-module",
             "extra": {

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -1,38 +1,37 @@
 {
-    "patches": {
-      "drupal/amazon_ses": {
-            "Cron fails on amazon_ses when not configured": "PATCHES/amazon_ses-3417090-cron-queue-14.patch"
-        },
-        "drupal/core" : {
-            "https://www.drupal.org/project/drupal/issues/3143617": "https://www.drupal.org/files/issues/2020-07-07/3143617-28_0.patch",
-            "Include database SSL/TLS info on status report": "./PATCHES/mysql-ssl-status.patch"
-        },
-        "drupal/csp": {
-            "Simplify log format": "PATCHES/csp-log-format.patch"
-        },
-        "drupal/group": {
-            "https://www.drupal.org/project/subgroup/issues/3163044#comment-14499262": "https://www.drupal.org/files/issues/2022-05-04/i3278723.patch",
-            "https://www.drupal.org/project/group/issues/3212608 - views data export": "https://www.drupal.org/files/issues/2022-10-19/3212608-5_0.patch"
-        },
-        "drupal/linkchecker": {
-            "Provide a list of unconfigured but eligible fields - https://www.drupal.org/project/linkchecker/issues/3244743": "PATCHES/linkchecker-unconfirmed-but-eligible-field-list-3244743.patch",
-            "Do not break admin denied": "./PATCHES/linkchecker_use_uid.patch",
-            "Avoid null links": "./PATCHES/linkchecker_null_link.patch",
-            "Recognize previous revisions https://www.drupal.org/project/linkchecker/issues/3366753": "./PATCHES/linkchecker-previous-revisions-3366753.patch",
-            "DER 1.16 - https://www.drupal.org/project/linkchecker/issues/3346793": "https://git.drupalcode.org/project/linkchecker/-/merge_requests/41.patch"
-        },
-        "drupal/social_auth_hid": {
-            "Keep lang prefix in URL": "./PATCHES/hid_lang.patch"
-        },
-        "drupal/user_expire": {
-            "Allow the notification email to be customised": "PATCHES/user_expire-customize-notification-email.patch",
-            "Reset expiration when user is reactivated": "PATCHES/user_expire-reset-expiration-on-reactivation.patch"
-        },
-        "drupal/username_enumeration_prevention": {
-            "Avoid leaking the path via Drupal.settings json": "PATCHES/username_enumeration_prevention-user-login-block-form-3312288.patch"
-        },
-        "mailchimp/marketing": {
-            "PHP 8.2": "PATCHES/mailchimp_php82.patch"
-        }
+  "patches": {
+    "drupal/amazon_ses": {
+      "Cron fails on amazon_ses when not configured": "PATCHES/amazon_ses-3417090-cron-queue-14.patch"
+    },
+    "drupal/core" : {
+      "https://www.drupal.org/project/drupal/issues/3143617": "https://www.drupal.org/files/issues/2020-07-07/3143617-28_0.patch",
+      "Include database SSL/TLS info on status report": "./PATCHES/mysql-ssl-status.patch"
+    },
+    "drupal/csp": {
+      "Simplify log format": "PATCHES/csp-log-format.patch"
+    },
+    "drupal/group": {
+      "https://www.drupal.org/project/subgroup/issues/3163044#comment-14499262": "https://www.drupal.org/files/issues/2022-05-04/i3278723.patch",
+      "https://www.drupal.org/project/group/issues/3212608 - views data export": "https://www.drupal.org/files/issues/2022-10-19/3212608-5_0.patch"
+    },
+    "drupal/linkchecker": {
+      "Provide a list of unconfigured but eligible fields - https://www.drupal.org/project/linkchecker/issues/3244743": "PATCHES/linkchecker-unconfirmed-but-eligible-field-list-3244743.patch",
+      "Do not break admin denied": "./PATCHES/linkchecker_use_uid.patch",
+      "Avoid null links": "./PATCHES/linkchecker_null_link.patch",
+      "Recognize previous revisions https://www.drupal.org/project/linkchecker/issues/3366753": "./PATCHES/linkchecker-previous-revisions-3366753.patch"
+    },
+    "drupal/social_auth_hid": {
+      "Keep lang prefix in URL": "./PATCHES/hid_lang.patch"
+    },
+    "drupal/user_expire": {
+      "Allow the notification email to be customised": "PATCHES/user_expire-customize-notification-email.patch",
+      "Reset expiration when user is reactivated": "PATCHES/user_expire-reset-expiration-on-reactivation.patch"
+    },
+    "drupal/username_enumeration_prevention": {
+      "Avoid leaking the path via Drupal.settings json": "PATCHES/username_enumeration_prevention-user-login-block-form-3312288.patch"
+    },
+    "mailchimp/marketing": {
+      "PHP 8.2": "PATCHES/mailchimp_php82.patch"
     }
+  }
 }


### PR DESCRIPTION
Refs: OPS-10181

Tried updating dynamic_entity_reference module so we could remove a patch to use an earlier version https://www.drupal.org/project/linkchecker/issues/3346793 - but turns out it had already been updated so the patch wasn't needed.

I also made whitespace consistent in the patch https://github.com/UN-OCHA/response-site/compare/OPS-10181-avoid-alterable-patches?expand=1&w=1 shows the actual change.