### PR TITLE
fix(river): show true datasource on HDX rivers

### DIFF
--- a/html/modules/custom/hr_paragraphs/src/Controller/HdxController.php
+++ b/html/modules/custom/hr_paragraphs/src/Controller/HdxController.php
@@ -510,7 +510,7 @@ class HdxController extends ControllerBase {
         'primary_country' => $row['groups'][0]['title'],
         'countries' => $row['groups'],
         'format' => 'Dataset',
-        'sources' => 'HDX',
+        'sources' => $row['dataset_source'] ?? 'HDX',
       ];
 
       if (isset($row['groups'])) {


### PR DESCRIPTION
Refs: RWR-425

## Testing

Go to any operation with a Data tab activated and see whether the sources are populated. They used to be hardcoded to `'HDX'` but they should show the real source now like so:

<img width="821" alt="RWR-425-sources" src="https://github.com/UN-OCHA/response-site/assets/254753/8f192695-61d4-46c8-8912-f5c967691ea5">
