### PR TITLE
Feature/ops 10398 sec kit

### DIFF
--- a/config/seckit.settings.yml
+++ b/config/seckit.settings.yml
@@ -8,9 +8,9 @@ seckit_xss:
       webkit: false
     report-only: false
     default-src: "'self'"
-    script-src: "'self' 'unsafe-inline' fonts.googleapis.com www.gstatic.com https://*.google.com https://*.googletagmanager.com *.google-analytics.com https://tagmanager.google.com  https://www.googleadservices.com  https://googleads.g.doubleclick.net"
+    script-src: "'self' 'unsafe-inline' fonts.googleapis.com www.gstatic.com https://*.google.com https://*.googletagmanager.com *.google-analytics.com https://tagmanager.google.com  https://www.googleadservices.com  https://googleads.g.doubleclick.net cdnjs.cloudflare.com"
     object-src: "'none'"
-    style-src: "'self' 'unsafe-inline' https://googletagmanager.com https://tagmanager.google.com fonts.googleapis.com"
+    style-src: "'self' 'unsafe-inline' https://googletagmanager.com https://tagmanager.google.com fonts.googleapis.com cdnjs.cloudflare.com"
     img-src: "'self' data: https://*.google-analytics.com https://*.googletagmanager.com gstatic.com https://googleads.g.doubleclick.net https://www.google.com https://google.com ytimg.com reliefweb.int"
     media-src: "'none'"
     frame-src: "'self' https://www.googletagmanager.com https://bid.g.doubleclick.net https://td.doubleclick.net https://flo.uri.sh  https://api.mapbox.com https://app.powerbi.com https://data.humdata.org https://drive.google.com https://www.youtube.com https://datawrapper.dwcdn.net https://teamup.com https://lookerstudio.google.com https://experience.arcgis.com https://public.tableau.com https://rrmniger.azurewebsites.net/"

--- a/config/seckit.settings.yml
+++ b/config/seckit.settings.yml
@@ -8,12 +8,12 @@ seckit_xss:
       webkit: false
     report-only: false
     default-src: "'self'"
-    script-src: "'self' 'unsafe-inline' 'unsafe-eval' fonts.googleapis.com www.gstatic.com https://*.google.com https://*.googletagmanager.com cdn.jsdelivr.net *.google-analytics.com https://cdnjs.cloudflare.com"
+    script-src: "'self' 'unsafe-inline' fonts.googleapis.com www.gstatic.com https://*.google.com https://*.googletagmanager.com *.google-analytics.com https://tagmanager.google.com  https://www.googleadservices.com  https://googleads.g.doubleclick.net"
     object-src: "'none'"
-    style-src: "'self' 'unsafe-inline' fonts.googleapis.com https://cdnjs.cloudflare.com"
-    img-src: "'self' data: https://*.google-analytics.com https://*.googletagmanager.com gstatic.com ytimg.com reliefweb.int"
+    style-src: "'self' 'unsafe-inline' https://googletagmanager.com https://tagmanager.google.com fonts.googleapis.com"
+    img-src: "'self' data: https://*.google-analytics.com https://*.googletagmanager.com gstatic.com https://googleads.g.doubleclick.net https://www.google.com https://google.com ytimg.com reliefweb.int"
     media-src: "'none'"
-    frame-src: "'self'  https://flo.uri.sh  https://api.mapbox.com https://app.powerbi.com"
+    frame-src: "'self' https://www.googletagmanager.com https://bid.g.doubleclick.net https://td.doubleclick.net https://flo.uri.sh  https://api.mapbox.com https://app.powerbi.com"
     frame-ancestors: "'self'"
     child-src: "'self'"
     font-src: "'self' data: fonts.gstatic.com"


### PR DESCRIPTION
This adds google domains as per OPS-10457, but it also removes a couple of things from script-src which we aren't using elsewhere any longer.

One is 'unsafe-eval', which I hope we aren't actually using anywhere, the other is cdn.jsdelivr.net, which I believe was for new relic.