### PR TITLE
chore: add patch to avoid getPluginId error

### DIFF
--- a/composer.patches.json
+++ b/composer.patches.json
@@ -12,6 +12,7 @@
     },
     "drupal/group": {
       "https://www.drupal.org/project/subgroup/issues/3163044#comment-14499262": "https://www.drupal.org/files/issues/2022-05-04/i3278723.patch",
+      "https://www.drupal.org/project/group/issues/3399452 - getPluginId error": "https://www.drupal.org/files/issues/2023-11-06/group-3399452-2.patch",
       "https://www.drupal.org/project/group/issues/3212608 - views data export": "https://www.drupal.org/files/issues/2022-10-19/3212608-5_0.patch"
     },
     "drupal/linkchecker": {

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -12,7 +12,7 @@
     },
     "drupal/group": {
       "https://www.drupal.org/project/subgroup/issues/3163044#comment-14499262": "https://www.drupal.org/files/issues/2022-05-04/i3278723.patch",
-      "https://www.drupal.org/project/group/issues/3399452 - getPluginId error": "https://www.drupal.org/files/issues/2023-11-06/group-3399452-2.patch",
+      "https://www.drupal.org/project/group/issues/3310248 - getPluginId error": "https://www.drupal.org/files/issues/2022-09-18/group-3310248-5.patch",
       "https://www.drupal.org/project/group/issues/3212608 - views data export": "https://www.drupal.org/files/issues/2022-10-19/3212608-5_0.patch"
     },
     "drupal/linkchecker": {


### PR DESCRIPTION
Refs: OPS-10472

This is a fix for a problem unearthed by the sesame health checks. 

I was going to go with patch 2 in https://www.drupal.org/project/group/issues/3399452 but the module maintainer doesn't like either patch, so I went for the simpler one from https://www.drupal.org/project/group/issues/3310248.