### PR TITLE
fix: Ensure that hr_paragraphs depends on the module whose classes it uses.

### DIFF
--- a/html/modules/custom/hr_paragraphs/hr_paragraphs.info.yml
+++ b/html/modules/custom/hr_paragraphs/hr_paragraphs.info.yml
@@ -4,3 +4,4 @@ type: module
 core_version_requirement: ^8 || ^9 || ^10
 dependencies:
   - paragraphs:paragraphs
+  - social_auth:social_auth


### PR DESCRIPTION
Because otherwise, you get bad errors when you try to uninstall them.

Refs: OPS-10529