### PR TITLE
Deploy 21-11-2024

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 All notable changes to this project will be documented in this file.
 <!--- END HEADER -->
 
+## [1.3.1](https://github.com/UN-OCHA/response-site/compare/v1.3.0...v1.3.1) (2024-11-21)
+
+### Chores
+
+* Update all outdated drupal/* unocha/* drush/* packages. ([d0c654](https://github.com/UN-OCHA/response-site/commit/d0c654d6f9d2d273e26c34691fd18a33c1ebf5b6))
+
 ## [1.3.0](https://github.com/UN-OCHA/response-site/compare/v1.2.9...v1.3.0) (2024-11-18)
 
 ### Features

--- a/composer.json
+++ b/composer.json
@@ -238,7 +238,7 @@
             ]
         }
     },
-    "version": "1.3.0",
+    "version": "1.3.1",
     "require-dev": {
         "davidrjonas/composer-lock-diff": "^1.7",
         "drupal/coder": "^8.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a12975f3b19a24a37a00245e1b289ee5",
+    "content-hash": "192d53380eaefeacea5c2f896781a3ab",
     "packages": [
         {
             "name": "asm89/stack-cors",


### PR DESCRIPTION
## [1.3.1](https://github.com/UN-OCHA/response-site/compare/v1.3.0...v1.3.1) (2024-11-21)

### Chores

* Update all outdated drupal/* unocha/* drush/* packages. ([d0c654](https://github.com/UN-OCHA/response-site/commit/d0c654d6f9d2d273e26c34691fd18a33c1ebf5b6))

## Composer changes

| Production Changes            | From    | To      | Compare                                                                         |
|-------------------------------|---------|---------|---------------------------------------------------------------------------------|
| aws/aws-sdk-php               | 3.326.0 | 3.328.3 | [...](https://github.com/aws/aws-sdk-php/compare/3.326.0...3.328.3)             |
| drupal/core                   | 10.3.8  | 10.3.9  | [...](https://github.com/drupal/core/compare/10.3.8...10.3.9)                   |
| drupal/core-composer-scaffold | 10.3.8  | 10.3.9  | [...](https://github.com/drupal/core-composer-scaffold/compare/10.3.8...10.3.9) |
| drupal/core-project-message   | 10.3.8  | 10.3.9  | [...](https://github.com/drupal/core-project-message/compare/10.3.8...10.3.9)   |
| drupal/core-recommended       | 10.3.8  | 10.3.9  | [...](https://github.com/drupal/core-recommended/compare/10.3.8...10.3.9)       |
| drupal/theme_switcher         | 2.0.1   | 2.1.0   | [...](https://git.drupalcode.org/project/theme_switcher/compare/2.0.1...2.1.0)  |

