### PR TITLE
fix: handle snaps with undefined language

### DIFF
--- a/html/modules/custom/rwr_sitrep/rwr_sitrep.module
+++ b/html/modules/custom/rwr_sitrep/rwr_sitrep.module
@@ -23,7 +23,7 @@ use Drupal\taxonomy\Entity\Term;
 function rwr_sitrep_menu_local_tasks_alter(&$data, $route_name, RefinableCacheableDependencyInterface &$cacheability) {
   $show_operation_sitreps = FALSE;
 
-  /** @var \Drupal\group\Entity\Group */
+  /** @var \Drupal\group\Entity\Group|null */
   $group = \Drupal::routeMatch()->getParameter('group');
   if (!$group) {
     return;

--- a/html/themes/custom/common_design_subtheme/templates/node--page--full--pdf.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/node--page--full--pdf.html.twig
@@ -90,7 +90,7 @@
 {{ attach_library('common_design/cd-other') }}
 {{ attach_library('common_design_subtheme/sitrep') }}
 
-{% if node.langcode.langcode == 'en' %}
+{% if node.langcode.langcode in ['en', 'und', 'zxx'] %}
   {% set snap_url = '/node/' ~ node.id() ~ '/pdf' %}
 {% else %}
   {% set snap_url = '/' ~ node.langcode.langcode ~ '/node/' ~ node.id() ~ '/pdf' %}


### PR DESCRIPTION
Refs: RWR-495

This fix makes me think I should be passing the language along in a better way, but this avoids snap failing when content language is 'undefined' or 'not applicable'. (And assumes undefined languages are all 'ltr').